### PR TITLE
fix: harden LAN remote access

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,15 +175,17 @@ The React app runs inside Qt's WebEngineView. When a video plays, React sends th
 The phone remote uses Server-Sent Events (SSE) for real-time communication:
 
 1. PC creates an RC session and generates a QR code containing `http://<lan-ip>:9630/api/rc/auth?session=X&token=Y`
-2. Phone scans QR, authenticates, and connects to the SSE stream
+2. Phone scans QR, authenticates once, receives session cookies, and connects to the SSE stream
 3. PC reports playback state every second; phone sends commands via POST
 4. Commands route through the mpv bridge (play/pause/seek/volume/subtitles)
 
 The app binds to `0.0.0.0` so phones on the same LAN can reach it. Firewall port 9630 is opened by the install script.
 
+Non-local API access is now scoped to an authenticated paired remote session. Browsing and playback-control routes are available to the phone after pairing, while config, VPN, and media-stream endpoints stay local-only on the desktop.
+
 ### Privacy Architecture
 
-**Debrid path:** Magnet link → Real-Debrid API → HTTPS download URL → stream to player. User's IP only visible to RD (encrypted HTTPS), never to the torrent swarm.
+**Debrid path:** Magnet link → Real-Debrid API → server-held HTTPS download URL → internal stream handle → player. User's IP only visible to RD (encrypted HTTPS), never to the torrent swarm, and raw debrid URLs are not exposed as public API input.
 
 **VPN path:** `rattin-vpn` supervisor creates a Linux network namespace with a WireGuard tunnel. Node.js runs inside the namespace. All torrent traffic (peers, DHT, trackers) goes through the VPN. The browser connects to the API via a veth bridge (`10.199.199.0/24`). If the WireGuard tunnel drops, there's no fallback route — connections fail instead of leaking the real IP.
 

--- a/lib/access-control.ts
+++ b/lib/access-control.ts
@@ -1,0 +1,139 @@
+import type { Request, RequestHandler } from "express";
+import type { RCSession, ServerContext } from "./types.js";
+
+type CookieMap = Record<string, string>;
+
+interface CookieOptions {
+  httpOnly?: boolean;
+}
+
+interface RcAuthResult {
+  sessionId: string;
+  session: RCSession;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readCookieMap(req: Request): CookieMap {
+  return ((req as Request & { cookies?: CookieMap }).cookies || {}) as CookieMap;
+}
+
+function firstHeaderValue(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return readString(value[0]);
+  return readString(value);
+}
+
+function normalizeIp(ip: string | null): string | null {
+  if (!ip) return null;
+  const trimmed = ip.trim();
+  return trimmed.startsWith("::ffff:") ? trimmed.slice(7) : trimmed;
+}
+
+function requestPath(req: Request): string {
+  return req.originalUrl.split("?")[0] || req.originalUrl;
+}
+
+export function buildCookie(name: string, value: string, maxAgeSeconds: number, options: CookieOptions = {}): string {
+  const parts = [
+    `${name}=${encodeURIComponent(value)}`,
+    "Path=/",
+    `Max-Age=${maxAgeSeconds}`,
+    "SameSite=Lax",
+  ];
+  if (options.httpOnly) parts.push("HttpOnly");
+  return parts.join("; ");
+}
+
+export function clearCookie(name: string, options: CookieOptions = {}): string {
+  return buildCookie(name, "", 0, options);
+}
+
+export function getRequestIp(req: Request): string | null {
+  const socketIp = normalizeIp(req.socket.remoteAddress || null);
+  const forwarded = firstHeaderValue(req.headers["x-forwarded-for"]);
+  if ((socketIp === "127.0.0.1" || socketIp === "::1") && forwarded) {
+    return normalizeIp(forwarded.split(",")[0]?.trim() || null);
+  }
+  return socketIp;
+}
+
+export function isLocalRequest(req: Request): boolean {
+  const ip = getRequestIp(req);
+  return ip === "127.0.0.1" || ip === "::1";
+}
+
+export function getRcSessionId(req: Request): string | null {
+  const cookies = readCookieMap(req);
+  const body = (req.body || {}) as { sessionId?: unknown };
+  return readString(req.params?.sessionId)
+    || readString(req.query?.session)
+    || readString(body.sessionId)
+    || readString(cookies.rc_session);
+}
+
+export function getRcAuthToken(req: Request): string | null {
+  const cookies = readCookieMap(req);
+  const body = (req.body || {}) as { authToken?: unknown; token?: unknown };
+  const authHeader = firstHeaderValue(req.headers.authorization);
+  return readString(req.query?.token)
+    || readString(body.authToken)
+    || readString(body.token)
+    || firstHeaderValue(req.headers["x-rattin-rc-token"])
+    || (authHeader?.toLowerCase().startsWith("bearer ") ? authHeader.slice(7).trim() : authHeader)
+    || readString(cookies.rc_token);
+}
+
+export function getAuthorizedRcSession(
+  req: Request,
+  rcSessions: Map<string, RCSession>,
+  options: { touch?: boolean } = {},
+): RcAuthResult | null {
+  const sessionId = getRcSessionId(req);
+  const token = getRcAuthToken(req);
+  if (!sessionId || !token) return null;
+  const session = rcSessions.get(sessionId);
+  if (!session || !session.authToken || session.authToken !== token) return null;
+  if (options.touch !== false) session.lastActivity = Date.now();
+  return { sessionId, session };
+}
+
+function isRemoteSafeRoute(req: Request): boolean {
+  const path = requestPath(req);
+  const { method } = req;
+
+  if (method === "GET" && path === "/api/rc/auth") return true;
+  if (method === "GET" && path === "/api/tmdb/status") return true;
+  if (method === "GET" && path.startsWith("/api/tmdb/")) return true;
+  if (method === "GET" && path.startsWith("/api/reviews/")) return true;
+  if (method === "POST" && path === "/api/check-availability") return true;
+  if (method === "POST" && path === "/api/search-streams") return true;
+  if (method === "POST" && path === "/api/auto-play") return true;
+  if (method === "POST" && path === "/api/play-torrent") return true;
+  if (method === "GET" && /^\/api\/rc\/session\/[^/]+$/.test(path)) return true;
+  if (method === "DELETE" && /^\/api\/rc\/session\/[^/]+$/.test(path)) return true;
+  if (method === "GET" && path === "/api/rc/events") return true;
+  if (method === "POST" && path === "/api/rc/command") return true;
+  if (method === "POST" && path === "/api/rc/request-qr") return true;
+
+  return false;
+}
+
+export function createApiAccessControl(ctx: ServerContext): RequestHandler {
+  return (req, res, next) => {
+    if (isLocalRequest(req)) return next();
+
+    if (requestPath(req) === "/api/rc/auth") return next();
+
+    if (!getAuthorizedRcSession(req, ctx.rcSessions, { touch: false })) {
+      return res.status(401).json({ error: "remote_auth_required" });
+    }
+
+    if (!isRemoteSafeRoute(req)) {
+      return res.status(403).json({ error: "local_only" });
+    }
+
+    next();
+  };
+}

--- a/lib/debrid.ts
+++ b/lib/debrid.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync, mkdirSync, unlinkSync, existsSync } from "fs";
+import crypto from "crypto";
 import path from "path";
 import { configDir } from "./paths.js";
 
@@ -480,12 +481,21 @@ function isVideoFile(filePath: string): boolean {
 interface ActiveDebridStream {
   url: string;
   files: DebridFileInfo[];
+  streamKey: string;
 }
 
 const _activeDebridStreams = new Map<string, ActiveDebridStream>();
+const _activeDebridKeys = new Map<string, string>();
 
-export function setActiveDebridStream(infoHash: string, url: string, files: DebridFileInfo[]): void {
-  _activeDebridStreams.set(infoHash.toLowerCase(), { url, files });
+export function setActiveDebridStream(infoHash: string, url: string, files: DebridFileInfo[]): string {
+  const normalized = infoHash.toLowerCase();
+  const previous = _activeDebridStreams.get(normalized);
+  if (previous) _activeDebridKeys.delete(previous.streamKey);
+
+  const streamKey = crypto.randomBytes(16).toString("hex");
+  _activeDebridStreams.set(normalized, { url, files, streamKey });
+  _activeDebridKeys.set(streamKey, normalized);
+  return streamKey;
 }
 
 export function getActiveDebridUrl(infoHash: string, fileIndex: number): string | null {
@@ -494,6 +504,12 @@ export function getActiveDebridUrl(infoHash: string, fileIndex: number): string 
 
 export function getActiveDebridFiles(infoHash: string): DebridFileInfo[] {
   return _activeDebridStreams.get(infoHash.toLowerCase())?.files || [];
+}
+
+export function getActiveDebridStreamByKey(streamKey: string): ActiveDebridStream | null {
+  const infoHash = _activeDebridKeys.get(streamKey);
+  if (!infoHash) return null;
+  return _activeDebridStreams.get(infoHash) || null;
 }
 
 let _provider: DebridProvider | null | undefined; // undefined = not loaded yet

--- a/routes/rc.ts
+++ b/routes/rc.ts
@@ -1,15 +1,37 @@
 import crypto from "crypto";
 import os from "os";
 import type { Express, Request, Response } from "express";
+import { buildCookie, clearCookie, getRcAuthToken, getRcSessionId } from "../lib/access-control.js";
 import type { ServerContext, RCSession, RCClient } from "../lib/types.js";
 
 export default function rcRoutes(app: Express, ctx: ServerContext): void {
   const { log, pcAuthToken, rcSessions } = ctx;
 
-  function rcSession(id: string): RCSession | null {
-    const s = rcSessions.get(id);
-    if (s) s.lastActivity = Date.now();
-    return s || null;
+  function authorizeSession(
+    req: Request,
+    res: Response,
+    options: { notFoundError: string },
+  ): { sessionId: string; session: RCSession } | null {
+    const sessionId = getRcSessionId(req);
+    if (!sessionId) {
+      res.status(400).json({ error: "sessionId required" });
+      return null;
+    }
+
+    const session = rcSessions.get(sessionId);
+    if (!session) {
+      res.status(404).json({ error: options.notFoundError });
+      return null;
+    }
+
+    const token = getRcAuthToken(req);
+    if (!token || !session.authToken || session.authToken !== token) {
+      res.status(401).json({ error: "invalid_token" });
+      return null;
+    }
+
+    session.lastActivity = Date.now();
+    return { sessionId, session };
   }
 
   function sseWrite(res: RCClient, event: string, data: unknown): void {
@@ -23,8 +45,7 @@ export default function rcRoutes(app: Express, ctx: ServerContext): void {
   app.get("/api/auth/persist", (req: Request, res: Response) => {
     // Only reachable after nginx basic auth succeeded (or a valid token).
     // Set a long-lived cookie — nginx skips basic auth when rc_auth cookie exists.
-    res.setHeader("Set-Cookie",
-      `rc_auth=${pcAuthToken}; Path=/; Max-Age=${30 * 24 * 60 * 60}; SameSite=Lax`);
+    res.setHeader("Set-Cookie", buildCookie("rc_auth", pcAuthToken, 30 * 24 * 60 * 60, { httpOnly: true }));
     res.json({ ok: true });
   });
 
@@ -59,11 +80,9 @@ export default function rcRoutes(app: Express, ctx: ServerContext): void {
 
   // Session status probe (used by phone to detect expired sessions)
   app.get("/api/rc/session/:sessionId", (req: Request, res: Response) => {
-    const { sessionId } = req.params as Record<string, string>;
-    const s = rcSessions.get(sessionId);
-    if (!s) return res.status(404).json({ error: "session_expired" });
-    s.lastActivity = Date.now();
-    res.json({ exists: true, playerOnline: !!s.playerClient });
+    const auth = authorizeSession(req, res, { notFoundError: "session_expired" });
+    if (!auth) return;
+    res.json({ exists: true, playerOnline: !!auth.session.playerClient });
   });
 
   // Phone remote auth — validates token, sets cookie, redirects to /remote
@@ -77,29 +96,35 @@ export default function rcRoutes(app: Express, ctx: ServerContext): void {
     s.lastActivity = Date.now();
     // Set a long-lived cookie that nginx checks to skip basic auth
     res.setHeader("Set-Cookie", [
-      `rc_auth=${token}; Path=/; Max-Age=${60 * 60 * 24}; SameSite=Lax`,
-      `rc_token=${token}; Path=/; Max-Age=${60 * 60 * 24}; SameSite=Lax`,
+      buildCookie("rc_auth", token, 60 * 60 * 24, { httpOnly: true }),
+      buildCookie("rc_token", token, 60 * 60 * 24, { httpOnly: true }),
+      buildCookie("rc_session", session, 60 * 60 * 24),
     ]);
-    res.redirect(`/remote?session=${session}`);
+    res.redirect("/remote");
   });
 
   // Delete session
   app.delete("/api/rc/session/:sessionId", (req: Request, res: Response) => {
-    const { sessionId } = req.params as Record<string, string>;
-    const s = rcSessions.get(sessionId);
-    if (!s) return res.status(404).json({ error: "session not found" });
-    if (s.playerClient) s.playerClient.end();
-    for (const c of s.remoteClients) c.end();
-    rcSessions.delete(sessionId);
-    log("info", "RC session deleted", { sessionId });
+    const auth = authorizeSession(req, res, { notFoundError: "session not found" });
+    if (!auth) return;
+    if (auth.session.playerClient) auth.session.playerClient.end();
+    for (const c of auth.session.remoteClients) c.end();
+    rcSessions.delete(auth.sessionId);
+    log("info", "RC session deleted", { sessionId: auth.sessionId });
+    res.setHeader("Set-Cookie", [
+      clearCookie("rc_auth", { httpOnly: true }),
+      clearCookie("rc_token", { httpOnly: true }),
+      clearCookie("rc_session"),
+    ]);
     res.json({ ok: true });
   });
 
   // SSE event stream
   app.get("/api/rc/events", (req: Request, res: Response) => {
-    const { session, role } = req.query as { session?: string; role?: string };
-    const s = rcSession(session || "");
-    if (!s) return res.status(404).json({ error: "session not found" });
+    const { role } = req.query as { role?: string };
+    const auth = authorizeSession(req, res, { notFoundError: "session not found" });
+    if (!auth) return;
+    const s = auth.session;
 
     res.writeHead(200, {
       "Content-Type": "text/event-stream",
@@ -148,31 +173,34 @@ export default function rcRoutes(app: Express, ctx: ServerContext): void {
 
   // Command (phone → PC)
   app.post("/api/rc/command", (req: Request, res: Response) => {
-    const { sessionId, action, value } = req.body as { sessionId: string; action: string; value?: unknown };
-    const s = rcSession(sessionId);
-    if (!s) return res.status(404).json({ error: "session not found" });
-    if (s.playerClient) {
-      sseWrite(s.playerClient, "command", { action, value });
+    const { action, value } = req.body as { action: string; value?: unknown };
+    const auth = authorizeSession(req, res, { notFoundError: "session not found" });
+    if (!auth) return;
+    if (auth.session.playerClient) {
+      sseWrite(auth.session.playerClient, "command", { action, value });
     }
     res.json({ ok: true });
   });
 
-  // Phone requests player to show QR for reconnection
-  // Broadcasts to ALL active player SSE connections (phone doesn't know which session is current)
-  app.post("/api/rc/request-qr", (_req: Request, res: Response) => {
-    for (const [, s] of rcSessions) {
-      if (s.playerClient) sseWrite(s.playerClient, "show-qr", {});
-    }
+  // Phone requests the paired player to show its QR again.
+  app.post("/api/rc/request-qr", (req: Request, res: Response) => {
+    const auth = authorizeSession(req, res, { notFoundError: "session not found" });
+    if (!auth) return;
+    if (auth.session.playerClient) sseWrite(auth.session.playerClient, "show-qr", {});
     res.json({ ok: true });
   });
 
   // State (PC → phone)
   app.post("/api/rc/state", (req: Request, res: Response) => {
-    const { sessionId, ...state } = req.body as { sessionId: string; [key: string]: unknown };
-    const s = rcSession(sessionId);
-    if (!s) return res.status(404).json({ error: "session not found" });
-    s.playbackState = state as RCSession["playbackState"];
-    for (const c of s.remoteClients) sseWrite(c, "state", state);
+    const { sessionId: _sessionId, authToken: _authToken, ...state } = req.body as {
+      sessionId: string;
+      authToken?: string;
+      [key: string]: unknown;
+    };
+    const auth = authorizeSession(req, res, { notFoundError: "session not found" });
+    if (!auth) return;
+    auth.session.playbackState = state as RCSession["playbackState"];
+    for (const c of auth.session.remoteClients) sseWrite(c, "state", state);
     res.json({ ok: true });
   });
 }

--- a/routes/search.ts
+++ b/routes/search.ts
@@ -439,7 +439,7 @@ interface TorrentPlayResult {
   torrentName: string;
   totalSize: number;
   tags: string[];
-  debridUrl?: string;
+  debridStreamKey?: string;
 }
 
 function respondWithTorrent(torrent: Torrent, season: number | undefined, episode: number | undefined, tags: string[], preferredFileIdx?: number): TorrentPlayResult | null {
@@ -535,7 +535,7 @@ app.post("/api/auto-play", async (req: Request, res: Response) => {
           if (cached.get(best.infoHash.toLowerCase())) {
             const stream = await debrid.unrestrict(magnet, best.fileIdx);
             log("info", "Auto-play via debrid (cached)", { name: best.name, filename: stream.filename });
-            setActiveDebridStream(best.infoHash, stream.url, stream.files);
+            const debridStreamKey = setActiveDebridStream(best.infoHash, stream.url, stream.files);
             return res.json({
               infoHash: best.infoHash,
               fileIndex: stream.fileIndex,
@@ -543,7 +543,7 @@ app.post("/api/auto-play", async (req: Request, res: Response) => {
               torrentName: best.name,
               totalSize: stream.filesize,
               tags,
-              debridUrl: stream.url,
+              debridStreamKey,
             } satisfies TorrentPlayResult);
           }
           log("info", "Debrid not cached, using WebTorrent", { name: best.name });
@@ -551,7 +551,7 @@ app.post("/api/auto-play", async (req: Request, res: Response) => {
           // Always wait for debrid — no fallback
           const stream = await debrid.unrestrict(magnet, best.fileIdx);
           log("info", "Auto-play via debrid", { name: best.name, filename: stream.filename });
-          setActiveDebridStream(best.infoHash, stream.url, stream.files);
+          const debridStreamKey = setActiveDebridStream(best.infoHash, stream.url, stream.files);
           return res.json({
             infoHash: best.infoHash,
             fileIndex: stream.fileIndex,
@@ -559,7 +559,7 @@ app.post("/api/auto-play", async (req: Request, res: Response) => {
             torrentName: best.name,
             totalSize: stream.filesize,
             tags,
-            debridUrl: stream.url,
+            debridStreamKey,
           } satisfies TorrentPlayResult);
         }
       } catch (err) {
@@ -675,7 +675,7 @@ app.post("/api/play-torrent", async (req: Request, res: Response) => {
         if (cached.get(infoHash.toLowerCase())) {
           const stream = await debrid.unrestrict(magnet, fileIdx);
           log("info", "Play-torrent via debrid (cached)", { infoHash, filename: stream.filename });
-          setActiveDebridStream(infoHash, stream.url, stream.files);
+          const debridStreamKey = setActiveDebridStream(infoHash, stream.url, stream.files);
           return res.json({
             infoHash,
             fileIndex: stream.fileIndex,
@@ -683,14 +683,14 @@ app.post("/api/play-torrent", async (req: Request, res: Response) => {
             torrentName: name || stream.filename,
             totalSize: stream.filesize,
             tags,
-            debridUrl: stream.url,
+            debridStreamKey,
           } satisfies TorrentPlayResult);
         }
         log("info", "Debrid not cached, using WebTorrent", { infoHash });
       } else {
         const stream = await debrid.unrestrict(magnet, fileIdx);
         log("info", "Play-torrent via debrid", { infoHash, filename: stream.filename });
-        setActiveDebridStream(infoHash, stream.url, stream.files);
+        const debridStreamKey = setActiveDebridStream(infoHash, stream.url, stream.files);
         return res.json({
           infoHash,
           fileIndex: stream.fileIndex,
@@ -698,7 +698,7 @@ app.post("/api/play-torrent", async (req: Request, res: Response) => {
           torrentName: name || stream.filename,
           totalSize: stream.filesize,
           tags,
-          debridUrl: stream.url,
+          debridStreamKey,
         } satisfies TorrentPlayResult);
       }
     } catch (err) {

--- a/routes/stream.ts
+++ b/routes/stream.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { statSync } from "fs";
 import type { Express, Request, Response, NextFunction } from "express";
+import { getActiveDebridStreamByKey } from "../lib/debrid.js";
 import { jobKey } from "../lib/torrent-caches.js";
 import { isAllowedFile, SUBTITLE_EXTENSIONS } from "../lib/media-utils.js";
 import {
@@ -126,10 +127,15 @@ export default function streamRoutes(app: Express, ctx: ServerContext): void {
   });
 
   // ── Debrid stream proxy ──────────────────────────────────────────
-  // Proxies a debrid direct download URL with range request support.
+  // Proxies an already-authorized debrid direct download URL with range request support.
   app.get("/api/debrid-stream", async (req: Request, res: Response) => {
-    const url = req.query.url as string;
-    if (!url) return res.status(400).json({ error: "url required" });
+    const streamKey = req.query.streamKey as string;
+    if (!streamKey) return res.status(400).json({ error: "streamKey required" });
+
+    const activeStream = getActiveDebridStreamByKey(streamKey);
+    if (!activeStream) return res.status(404).json({ error: "stream not found" });
+
+    const { url } = activeStream;
 
     const seekTo = parseFloat(req.query.t as string) || 0;
     const audioStreamIdx = req.query.audio ? parseInt(req.query.audio as string, 10) : null;

--- a/server.ts
+++ b/server.ts
@@ -6,6 +6,7 @@ import { sessionsPath, downloadDir } from "./lib/paths.js";
 import { tmdbCache } from "./lib/cache.js";
 import { pruneOrphans, cacheStats } from "./lib/torrent-caches.js";
 import { createIdleTracker } from "./lib/idle-tracker.js";
+import { createApiAccessControl } from "./lib/access-control.js";
 import { createContext } from "./lib/server-context.js";
 import rcRoutes from "./routes/rc.js";
 import tmdbRoutes from "./routes/tmdb.js";
@@ -62,6 +63,7 @@ app.use((req: Request, _res: Response, next: NextFunction) => {
   next();
 });
 app.use(express.static(path.join(__dirname, "public")));
+app.use("/api", createApiAccessControl(ctx));
 
 // ── Idle detection — escalating cleanup when app is unused ──
 const idleTracker = createIdleTracker({

--- a/src/components/PairRemoteModal.tsx
+++ b/src/components/PairRemoteModal.tsx
@@ -19,9 +19,9 @@ export default function PairRemoteModal({ onClose }: PairRemoteModalProps) {
 
   // On open, if we have a session, validate it's still alive on the server
   useEffect(() => {
-    if (!sessionId) return;
+    if (!sessionId || !authToken) return;
     setValidating(true);
-    fetch(`/api/rc/session/${sessionId}`)
+    fetch(`/api/rc/session/${sessionId}?token=${encodeURIComponent(authToken)}`)
       .then((res) => {
         if (!res.ok) {
           // Session expired on server — clear it
@@ -33,7 +33,7 @@ export default function PairRemoteModal({ onClose }: PairRemoteModalProps) {
       })
       .catch(() => {})
       .finally(() => setValidating(false));
-  }, []);
+  }, [authToken, sessionId, setRcAuthToken, setRcSessionId]);
 
   useEffect(() => {
     if (!sessionId || !authToken) {
@@ -67,8 +67,8 @@ export default function PairRemoteModal({ onClose }: PairRemoteModalProps) {
   }
 
   async function endSession() {
-    if (sessionId) {
-      await fetch(`/api/rc/session/${sessionId}`, { method: "DELETE" }).catch(() => {});
+    if (sessionId && authToken) {
+      await fetch(`/api/rc/session/${sessionId}?token=${encodeURIComponent(authToken)}`, { method: "DELETE" }).catch(() => {});
     }
     setSessionId(null);
     setAuthToken(null);

--- a/src/components/RemoteNowPlaying.tsx
+++ b/src/components/RemoteNowPlaying.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useRemoteMode } from "../lib/PlayerContext";
+import { clearRemoteSession } from "../lib/remote-session";
 import { formatTime } from "../lib/utils";
 import "../pages/Remote.css";
 
@@ -46,8 +47,7 @@ export default function RemoteNowPlaying() {
           .then((res) => {
             if (res.status === 404) {
               // Session expired — clear remote mode
-              localStorage.removeItem("rc-session");
-              localStorage.removeItem("rc-token");
+              clearRemoteSession();
               es.close();
               setState(null);
             }
@@ -82,7 +82,7 @@ export default function RemoteNowPlaying() {
   const dur = state.duration > 0 ? state.duration : lastGood.current.duration;
 
   return (
-    <div className="remote-now-playing" onClick={() => navigate(`/remote?session=${sessionId}`)}>
+    <div className="remote-now-playing" onClick={() => navigate("/remote")}>
       <div className="remote-now-playing-info">
         <div className="remote-now-playing-title">{state.title || "Now Playing"}</div>
         <div className="remote-now-playing-meta">

--- a/src/lib/PlayerContext.tsx
+++ b/src/lib/PlayerContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState, useRef, useCallback, useEffect, ty
 import type { SubtitleOption } from "./useSubtitles";
 import type { AudioTrackOption } from "./useAudioTracks";
 import { mpvTogglePause, mpvSetVolume, mpvSetSubFontSize, mpvStopAndWait } from "./native-bridge";
+import { getRemoteSessionId, REMOTE_SESSION_EVENT } from "./remote-session";
 
 interface ActiveStream {
   infoHash: string;
@@ -39,7 +40,7 @@ interface PlayerContextValue {
   currentTime: number;
   duration: number;
   volume: number;
-  startStream: (infoHash: string | number, fileIndex: string | number, title: string, tags: string[], debridUrl?: string) => void;
+  startStream: (infoHash: string | number, fileIndex: string | number, title: string, tags: string[], debridStreamKey?: string) => void;
   stopStream: () => void;
   togglePlay: () => void;
   effectiveTimeRef: MutableRefObject<EffectiveTime | null>;
@@ -72,32 +73,25 @@ export function usePlayer(): PlayerContextValue {
   return useContext(PlayerContext)!;
 }
 
-// Remote mode detection: URL has ?session=<id> or localStorage has rc-session
+// Remote mode detection is cookie-backed so the phone never needs auth data in the URL.
 export function useRemoteMode(): { isRemote: boolean; sessionId: string | null } {
   const [state, setState] = useState(() => {
-    const params = new URLSearchParams(window.location.search);
-    const sessionId = params.get("session") || localStorage.getItem("rc-session") || null;
+    const sessionId = getRemoteSessionId();
     return { isRemote: !!sessionId, sessionId };
   });
 
-  // Ensure rc_token cookie stays alive from localStorage (survives page refresh)
   useEffect(() => {
-    if (state.isRemote) {
-      const token = localStorage.getItem("rc-token");
-      if (token && !document.cookie.includes("rc_token=")) {
-        document.cookie = `rc_token=${token}; path=/; max-age=${60 * 60 * 24}; SameSite=Lax`;
-      }
-    }
-  }, [state.isRemote]);
-
-  useEffect(() => {
-    function check() {
-      const params = new URLSearchParams(window.location.search);
-      const sessionId = params.get("session") || localStorage.getItem("rc-session") || null;
+    function sync() {
+      const sessionId = getRemoteSessionId();
       setState({ isRemote: !!sessionId, sessionId });
     }
-    window.addEventListener("popstate", check);
-    return () => window.removeEventListener("popstate", check);
+
+    window.addEventListener("popstate", sync);
+    window.addEventListener(REMOTE_SESSION_EVENT, sync);
+    return () => {
+      window.removeEventListener("popstate", sync);
+      window.removeEventListener(REMOTE_SESSION_EVENT, sync);
+    };
   }, []);
 
   return state;
@@ -176,7 +170,7 @@ export function PlayerProvider({ children }: PlayerProviderProps) {
     return () => clearInterval(interval);
   }, []);
 
-  const startStream = useCallback((infoHash: string | number, fileIndex: string | number, title: string, tags: string[], _debridUrl?: string) => {
+  const startStream = useCallback((infoHash: string | number, fileIndex: string | number, title: string, tags: string[], _debridStreamKey?: string) => {
     if (active?.infoHash === String(infoHash) && String(active?.fileIndex) === String(fileIndex)) {
       return;
     }
@@ -243,7 +237,9 @@ export function PlayerProvider({ children }: PlayerProviderProps) {
   useEffect(() => {
     if (!rcSessionId) return;
 
-    const es = new EventSource(`/api/rc/events?session=${rcSessionId}&role=player`);
+    const query = new URLSearchParams({ session: rcSessionId, role: "player" });
+    if (rcAuthToken) query.set("token", rcAuthToken);
+    const es = new EventSource(`/api/rc/events?${query.toString()}`);
     rcEventSourceRef.current = es;
 
     es.addEventListener("command", (e: MessageEvent) => {
@@ -279,10 +275,10 @@ export function PlayerProvider({ children }: PlayerProviderProps) {
         case "start-stream":
           if (value) {
             const wasOnPlayer = window.location.pathname.startsWith("/play/");
-            console.log("[rc] start-stream", { infoHash: value.infoHash, title: value.title, wasOnPlayer, debridUrl: !!value.debridUrl });
+            console.log("[rc] start-stream", { infoHash: value.infoHash, title: value.title, wasOnPlayer, debridStreamKey: !!value.debridStreamKey });
 
             const navState = {
-              tags: value.tags, title: value.title, debridUrl: value.debridUrl,
+              tags: value.tags, title: value.title, debridStreamKey: value.debridStreamKey,
               year: value.year, type: value.type, season: value.season, episode: value.episode, imdbId: value.imdbId,
             };
 
@@ -292,12 +288,12 @@ export function PlayerProvider({ children }: PlayerProviderProps) {
               setSwitching(true);
               navigateRef.current?.("/", { replace: true });
               mpvStopAndWait().then(() => {
-                startStreamRef.current?.(value.infoHash, value.fileIndex, value.title, value.tags, value.debridUrl);
+                startStreamRef.current?.(value.infoHash, value.fileIndex, value.title, value.tags, value.debridStreamKey);
                 navigateRef.current?.(`/play/${value.infoHash}/${value.fileIndex}`, { state: navState });
                 setSwitching(false);
               });
             } else {
-              startStreamRef.current?.(value.infoHash, value.fileIndex, value.title, value.tags, value.debridUrl);
+              startStreamRef.current?.(value.infoHash, value.fileIndex, value.title, value.tags, value.debridStreamKey);
               navigateRef.current?.(`/play/${value.infoHash}/${value.fileIndex}`, { state: navState });
             }
           }
@@ -341,7 +337,7 @@ export function PlayerProvider({ children }: PlayerProviderProps) {
       rcEventSourceRef.current = null;
       setRcRemoteConnected(false);
     };
-  }, [rcSessionId]);
+  }, [rcAuthToken, rcSessionId]);
 
   // ── TV Mode: Report state to remotes ──
   useEffect(() => {
@@ -363,6 +359,7 @@ export function PlayerProvider({ children }: PlayerProviderProps) {
 
       const state = {
         sessionId: rcSessionId,
+        authToken: rcAuthToken,
         playing: playingRef.current,
         currentTime: ct,
         duration: dur,
@@ -407,7 +404,7 @@ export function PlayerProvider({ children }: PlayerProviderProps) {
       reportStateRef.current = null;
       if (stateReportTimer.current) clearInterval(stateReportTimer.current);
     };
-  }, [rcSessionId, active]);
+  }, [rcAuthToken, rcSessionId, active]);
 
   // Report immediately when playing state changes
   useEffect(() => {

--- a/src/lib/remote-session.ts
+++ b/src/lib/remote-session.ts
@@ -1,0 +1,29 @@
+export const REMOTE_SESSION_EVENT = "rattin:remote-session-changed";
+
+function expireCookie(name: string) {
+  document.cookie = `${name}=; path=/; max-age=0; SameSite=Lax`;
+}
+
+export function readCookie(name: string): string | null {
+  const prefix = `${name}=`;
+  const entry = document.cookie.split(";").map((part) => part.trim()).find((part) => part.startsWith(prefix));
+  if (!entry) return null;
+  return decodeURIComponent(entry.slice(prefix.length));
+}
+
+export function getRemoteSessionId(): string | null {
+  return readCookie("rc_session");
+}
+
+export function notifyRemoteSessionChanged(): void {
+  window.dispatchEvent(new Event(REMOTE_SESSION_EVENT));
+}
+
+export function clearRemoteSession(): void {
+  expireCookie("rc_session");
+  expireCookie("rc_token");
+  expireCookie("rc_auth");
+  localStorage.removeItem("rc-session");
+  localStorage.removeItem("rc-token");
+  notifyRemoteSessionChanged();
+}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -87,11 +87,11 @@ export default function Detail() {
         action: "start-stream",
         value: {
           infoHash: result.infoHash, fileIndex: result.fileIndex, title, tags,
-          debridUrl: result.debridUrl, year, type, season, episode, imdbId,
+          debridStreamKey: result.debridStreamKey, year, type, season, episode, imdbId,
         },
       }),
     }).catch(() => {});
-    navigate(`/remote?session=${sessionId}`, {
+    navigate("/remote", {
       state: { pendingTitle: title },
     });
   }
@@ -120,7 +120,7 @@ export default function Detail() {
         navState.season = pickerSeason;
         navState.episode = pickerEpisode;
       }
-      if (result.debridUrl) navState.debridUrl = result.debridUrl;
+      if (result.debridStreamKey) navState.debridStreamKey = result.debridStreamKey;
       navigate(`/play/${result.infoHash}/${result.fileIndex}`, { state: navState });
     } catch (err: unknown) {
       setPlayState("error");
@@ -146,7 +146,7 @@ export default function Detail() {
           navState.season = season;
           navState.episode = episode;
         }
-        if (result.debridUrl) navState.debridUrl = result.debridUrl;
+        if (result.debridStreamKey) navState.debridStreamKey = result.debridStreamKey;
         navigate(`/play/${result.infoHash}/${result.fileIndex}`, { state: navState });
       }
     } catch (err: unknown) {

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -81,13 +81,13 @@ export default function Player() {
       // Kill old player, wait for mpv to fully stop, then spawn new player
       navigate("/", { replace: true });
       await mpvStopAndWait();
-      startStream(result.infoHash, result.fileIndex, mediaTitle, newTags, result.debridUrl);
+      startStream(result.infoHash, result.fileIndex, mediaTitle, newTags, result.debridStreamKey);
       navigate(`/play/${result.infoHash}/${result.fileIndex}`, {
         state: {
           ...state,
           tags: newTags,
           sources,
-          debridUrl: result.debridUrl,
+          debridStreamKey: result.debridStreamKey,
         },
       });
     } catch {
@@ -152,7 +152,7 @@ export default function Player() {
   useEffect(() => {
     if (!infoHash || !fileIndex) return;
     if (active?.infoHash !== infoHash || String(active?.fileIndex) !== String(fileIndex)) {
-      startStream(infoHash, fileIndex, mediaTitle, tags, state?.debridUrl);
+      startStream(infoHash, fileIndex, mediaTitle, tags, state?.debridStreamKey);
     }
   }, [infoHash, fileIndex]);
 
@@ -166,9 +166,9 @@ export default function Player() {
       // Use 127.0.0.1 instead of localhost — mpv is a separate process and
       // localhost may resolve to ::1 (IPv6) while the server binds to 127.0.0.1
       const port = window.location.port;
-      const debridUrl = state?.debridUrl;
-      const streamUrl = debridUrl
-        ? debridUrl
+      const debridStreamKey = state?.debridStreamKey;
+      const streamUrl = debridStreamKey
+        ? `http://127.0.0.1:${port}/api/debrid-stream?streamKey=${encodeURIComponent(debridStreamKey)}`
         : `http://127.0.0.1:${port}/api/stream/${infoHash}/${fileIndex}`;
       console.log("[native-bridge] mpvPlay:", streamUrl);
       try {
@@ -337,9 +337,9 @@ export default function Player() {
     if (!hadRemote.current) return;
     // Check if existing session is still valid, if not create a new one
     async function ensureSession() {
-      if (rcSessionId) {
+      if (rcSessionId && rcAuthToken) {
         try {
-          const res = await fetch(`/api/rc/session/${rcSessionId}`);
+          const res = await fetch(`/api/rc/session/${rcSessionId}?token=${encodeURIComponent(rcAuthToken)}`);
           if (res.ok) return; // session still alive, QR will show
         } catch {}
       }
@@ -352,7 +352,7 @@ export default function Player() {
       } catch {}
     }
     ensureSession();
-  }, [rcRemoteConnected]);
+  }, [rcAuthToken, rcRemoteConnected, rcSessionId, setRcAuthToken, setRcSessionId]);
 
   // Auto-fullscreen when a remote reconnects
   useEffect(() => {

--- a/src/pages/Remote.tsx
+++ b/src/pages/Remote.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useSearchParams, useNavigate, useLocation } from "react-router-dom";
+import { clearRemoteSession, getRemoteSessionId } from "../lib/remote-session";
 import { formatTime, formatBytes } from "../lib/utils";
 import QrScanner from "../components/QrScanner";
 import "./Remote.css";
@@ -31,18 +32,17 @@ export default function Remote() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const location = useLocation();
-  const sessionId = searchParams.get("session") || localStorage.getItem("rc-session");
-  const token = searchParams.get("token");
+  const sessionId = getRemoteSessionId();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const pendingTitle = (location.state as any)?.pendingTitle || null;
 
-  // Set auth token as cookie so nginx bypasses basic auth for the phone
   useEffect(() => {
-    if (token) {
-      document.cookie = `rc_token=${token}; path=/; max-age=${60 * 60 * 24}; SameSite=Lax`;
-      localStorage.setItem("rc-token", token);
-    }
-  }, [token]);
+    const legacySession = searchParams.get("session");
+    const legacyToken = searchParams.get("token");
+    if (!legacySession || !legacyToken) return;
+    const params = new URLSearchParams({ session: legacySession, token: legacyToken });
+    window.location.replace(`/api/rc/auth?${params.toString()}`);
+  }, [searchParams]);
 
   // ── Core state ──
   const [remoteState, setRemoteState] = useState(sessionId ? S.CONNECTING : S.NO_SESSION);
@@ -86,32 +86,20 @@ export default function Remote() {
 
   function openScanner() {
     // Tell the player to show its QR code on screen
-    fetch("/api/rc/request-qr", { method: "POST" }).catch(() => {});
+    if (sessionId) {
+      fetch("/api/rc/request-qr", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId }),
+      }).catch(() => {});
+    }
     setShowScanner(true);
   }
 
   function handleQrScan(url: string) {
     setShowScanner(false);
-    // Parse session and token from the URL: /api/rc/auth?session=X&token=Y
-    try {
-      const parsed = new URL(url);
-      const newSession = parsed.searchParams.get("session");
-      const newToken = parsed.searchParams.get("token");
-      if (newSession && newToken) {
-        // Set cookie + localStorage, then navigate to the new session
-        document.cookie = `rc_token=${newToken}; path=/; max-age=${60 * 60 * 24}; SameSite=Lax`;
-        localStorage.setItem("rc-session", newSession);
-        localStorage.setItem("rc-token", newToken);
-        // Navigate — this triggers a fresh SSE connection via the useEffect
-        navigate(`/remote?session=${newSession}&token=${newToken}`, { replace: true });
-      }
-    } catch {}
+    window.location.assign(url);
   }
-
-  // Persist session
-  useEffect(() => {
-    if (sessionId) localStorage.setItem("rc-session", sessionId);
-  }, [sessionId]);
 
   // ── SSE connection with probe-based expiry detection ──
   useEffect(() => {
@@ -199,7 +187,7 @@ export default function Remote() {
   // Don't navigate during switching — the idle state is transient
   useEffect(() => {
     if (remoteState === S.CONNECTED_IDLE && hadPlayback.current && !state?.switching) {
-      navigate(`/?session=${sessionId}`, { replace: true });
+      navigate("/", { replace: true });
     }
   }, [remoteState, sessionId, navigate, state?.switching]);
 
@@ -223,8 +211,7 @@ export default function Remote() {
   }
 
   function clearSession() {
-    localStorage.removeItem("rc-session");
-    localStorage.removeItem("rc-token");
+    clearRemoteSession();
     if (esRef.current) { esRef.current.close(); esRef.current = null; }
     setRemoteState(S.NO_SESSION);
     setState(null);

--- a/test/routes/access-control.test.ts
+++ b/test/routes/access-control.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { startTestServer } from "../helpers/mock-app.js";
+
+function remoteHeaders(cookie?: string): HeadersInit {
+  return {
+    "X-Forwarded-For": "203.0.113.10",
+    ...(cookie ? { Cookie: cookie } : {}),
+  };
+}
+
+describe("API access control", () => {
+  let baseUrl: string, close: () => Promise<void>;
+
+  before(async () => {
+    ({ baseUrl, close } = await startTestServer());
+  });
+
+  after(async () => {
+    await close();
+  });
+
+  it("rejects unauthenticated non-local API requests", async () => {
+    const res = await fetch(`${baseUrl}/api/tmdb/status`, {
+      headers: remoteHeaders(),
+    });
+    assert.equal(res.status, 401);
+    const body = await res.json() as { error: string };
+    assert.equal(body.error, "remote_auth_required");
+  });
+
+  it("allows authenticated non-local remote-safe API requests", async () => {
+    const createRes = await fetch(`${baseUrl}/api/rc/session`, { method: "POST" });
+    const { sessionId, authToken } = await createRes.json() as { sessionId: string; authToken: string };
+
+    const res = await fetch(`${baseUrl}/api/tmdb/status`, {
+      headers: remoteHeaders(`rc_session=${sessionId}; rc_token=${authToken}`),
+    });
+    assert.equal(res.status, 200);
+  });
+
+  it("blocks authenticated non-local access to local-only API routes", async () => {
+    const createRes = await fetch(`${baseUrl}/api/rc/session`, { method: "POST" });
+    const { sessionId, authToken } = await createRes.json() as { sessionId: string; authToken: string };
+
+    const res = await fetch(`${baseUrl}/api/debrid/status`, {
+      headers: remoteHeaders(`rc_session=${sessionId}; rc_token=${authToken}`),
+    });
+    assert.equal(res.status, 403);
+    const body = await res.json() as { error: string };
+    assert.equal(body.error, "local_only");
+  });
+});

--- a/test/routes/debrid-stream.test.ts
+++ b/test/routes/debrid-stream.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { startTestServer } from "../helpers/mock-app.js";
+import { setActiveDebridStream } from "../../lib/debrid.js";
 
 describe("Debrid stream routes", () => {
   let baseUrl: string, close: () => Promise<void>;
@@ -14,15 +15,21 @@ describe("Debrid stream routes", () => {
   });
 
   describe("GET /api/debrid-stream", () => {
-    it("returns 400 when url param is missing", async () => {
+    it("returns 400 when streamKey param is missing", async () => {
       const res = await fetch(`${baseUrl}/api/debrid-stream`);
       assert.equal(res.status, 400);
       const body = await res.json() as { error: string };
-      assert.ok(body.error.includes("url"));
+      assert.ok(body.error.includes("streamKey"));
+    });
+
+    it("returns 404 for unknown streamKey", async () => {
+      const res = await fetch(`${baseUrl}/api/debrid-stream?streamKey=missing`);
+      assert.equal(res.status, 404);
     });
 
     it("returns 502 for unreachable debrid URL", async () => {
-      const res = await fetch(`${baseUrl}/api/debrid-stream?url=${encodeURIComponent("http://127.0.0.1:1/fake.mp4")}`);
+      const streamKey = setActiveDebridStream("deadbeef", "http://127.0.0.1:1/fake.mp4", []);
+      const res = await fetch(`${baseUrl}/api/debrid-stream?streamKey=${streamKey}`);
       // Should fail to connect and return an error
       assert.ok(res.status >= 400);
     });

--- a/test/routes/pipeline-consistency.test.ts
+++ b/test/routes/pipeline-consistency.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { startTestServer, type TestServerResult } from "../helpers/mock-app.js";
+import { setActiveDebridStream } from "../../lib/debrid.js";
 
 describe("Pipeline consistency", () => {
   let baseUrl: string, close: () => Promise<void>, ctx: TestServerResult;
@@ -45,25 +46,26 @@ describe("Pipeline consistency", () => {
   // ── /api/debrid-stream audio param forwarding ────────────────────
 
   describe("GET /api/debrid-stream", () => {
-    it("returns 400 when url is missing", async () => {
+    it("returns 400 when streamKey is missing", async () => {
       const res = await fetch(`${baseUrl}/api/debrid-stream`);
       assert.equal(res.status, 400);
       const body = await res.json() as { error: string };
-      assert.ok(body.error.includes("url"));
+      assert.ok(body.error.includes("streamKey"));
     });
 
-    it("returns 400 for invalid URL", async () => {
-      const res = await fetch(`${baseUrl}/api/debrid-stream?url=not-a-url`);
-      assert.equal(res.status, 400);
+    it("returns 404 for invalid stream key", async () => {
+      const res = await fetch(`${baseUrl}/api/debrid-stream?streamKey=not-a-key`);
+      assert.equal(res.status, 404);
       const body = await res.json() as { error: string };
-      assert.ok(body.error.includes("Invalid"));
+      assert.ok(body.error.includes("stream"));
     });
 
     it("accepts audio query param without crashing", async () => {
       // Will fail to connect but shouldn't crash on the audio param.
       // The transcode path sends headers before ffmpeg fails, so status may be 200.
       // The key assertion is that the server doesn't crash.
-      const res = await fetch(`${baseUrl}/api/debrid-stream?url=${encodeURIComponent("http://127.0.0.1:1/fake.mkv")}&audio=1`);
+      const streamKey = setActiveDebridStream("feedface", "http://127.0.0.1:1/fake.mkv", []);
+      const res = await fetch(`${baseUrl}/api/debrid-stream?streamKey=${streamKey}&audio=1`);
       assert.ok(typeof res.status === "number", "Server responded without crashing");
     });
   });

--- a/test/routes/rc.test.ts
+++ b/test/routes/rc.test.ts
@@ -5,6 +5,11 @@ import { startTestServer } from "../helpers/mock-app.js";
 describe("RC routes", () => {
   let baseUrl: string, close: () => Promise<void>;
 
+  async function createSession(): Promise<{ sessionId: string; authToken: string }> {
+    const res = await fetch(`${baseUrl}/api/rc/session`, { method: "POST" });
+    return res.json() as Promise<{ sessionId: string; authToken: string }>;
+  }
+
   before(async () => {
     ({ baseUrl, close } = await startTestServer());
   });
@@ -38,10 +43,9 @@ describe("RC routes", () => {
     });
 
     it("returns 200 for a valid session", async () => {
-      const createRes = await fetch(`${baseUrl}/api/rc/session`, { method: "POST" });
-      const { sessionId } = await createRes.json() as { sessionId: string };
+      const { sessionId, authToken } = await createSession();
 
-      const res = await fetch(`${baseUrl}/api/rc/session/${sessionId}`);
+      const res = await fetch(`${baseUrl}/api/rc/session/${sessionId}?token=${authToken}`);
       assert.equal(res.status, 200);
       const body = await res.json() as { exists: boolean; playerOnline: boolean };
       assert.equal(body.exists, true);
@@ -58,10 +62,9 @@ describe("RC routes", () => {
     });
 
     it("deletes an existing session", async () => {
-      const createRes = await fetch(`${baseUrl}/api/rc/session`, { method: "POST" });
-      const { sessionId } = await createRes.json() as { sessionId: string };
+      const { sessionId, authToken } = await createSession();
 
-      const delRes = await fetch(`${baseUrl}/api/rc/session/${sessionId}`, { method: "DELETE" });
+      const delRes = await fetch(`${baseUrl}/api/rc/session/${sessionId}?token=${authToken}`, { method: "DELETE" });
       assert.equal(delRes.status, 200);
       const body = await delRes.json() as { ok: boolean };
       assert.equal(body.ok, true);
@@ -85,13 +88,12 @@ describe("RC routes", () => {
     });
 
     it("returns 200 for valid session", async () => {
-      const createRes = await fetch(`${baseUrl}/api/rc/session`, { method: "POST" });
-      const { sessionId } = await createRes.json() as { sessionId: string };
+      const { sessionId, authToken } = await createSession();
 
       const res = await fetch(`${baseUrl}/api/rc/command`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId, action: "togglePlay" }),
+        body: JSON.stringify({ sessionId, authToken, action: "togglePlay" }),
       });
       assert.equal(res.status, 200);
       const body = await res.json() as { ok: boolean };
@@ -112,13 +114,12 @@ describe("RC routes", () => {
     });
 
     it("returns 200 for valid session", async () => {
-      const createRes = await fetch(`${baseUrl}/api/rc/session`, { method: "POST" });
-      const { sessionId } = await createRes.json() as { sessionId: string };
+      const { sessionId, authToken } = await createSession();
 
       const res = await fetch(`${baseUrl}/api/rc/state`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId, playing: true, currentTime: 42 }),
+        body: JSON.stringify({ sessionId, authToken, playing: true, currentTime: 42 }),
       });
       assert.equal(res.status, 200);
       const body = await res.json() as { ok: boolean };
@@ -135,12 +136,11 @@ describe("RC routes", () => {
     });
 
     it("returns SSE stream with correct content-type for valid session", async () => {
-      const createRes = await fetch(`${baseUrl}/api/rc/session`, { method: "POST" });
-      const { sessionId } = await createRes.json() as { sessionId: string };
+      const { sessionId, authToken } = await createSession();
 
       const controller = new AbortController();
       const res = await fetch(
-        `${baseUrl}/api/rc/events?session=${sessionId}&role=player`,
+        `${baseUrl}/api/rc/events?session=${sessionId}&role=player&token=${authToken}`,
         { signal: controller.signal }
       );
       assert.equal(res.status, 200);
@@ -178,8 +178,7 @@ describe("RC routes", () => {
     });
 
     it("returns 302 redirect with valid token", async () => {
-      const createRes = await fetch(`${baseUrl}/api/rc/session`, { method: "POST" });
-      const { sessionId, authToken } = await createRes.json() as { sessionId: string; authToken: string };
+      const { sessionId, authToken } = await createSession();
 
       const res = await fetch(
         `${baseUrl}/api/rc/auth?token=${authToken}&session=${sessionId}`,
@@ -187,7 +186,7 @@ describe("RC routes", () => {
       );
       assert.equal(res.status, 302);
       const location = res.headers.get("location")!;
-      assert.ok(location.includes(`/remote?session=${sessionId}`), "should redirect to /remote");
+      assert.equal(location, "/remote");
       const setCookie = res.headers.get("set-cookie")!;
       assert.ok(setCookie, "should set cookies");
       assert.ok(setCookie.includes("rc_auth="), "should set rc_auth cookie");


### PR DESCRIPTION
## Summary
- require an authenticated paired remote session for all non-local API access and keep config/media routes local-only
- enforce RC auth tokens on every session-bound route and move phone pairing to cookie-backed auth without leaving tokens in the SPA URL
- replace arbitrary `/api/debrid-stream?url=` proxying with server-issued debrid stream keys and update the player/remote flow accordingly

## Verification
- npm test
- npm run typecheck
- npm run build