### PR TITLE
fix: suppress cmd window on Windows when opening URLs

### DIFF
--- a/routes/open-url.ts
+++ b/routes/open-url.ts
@@ -12,13 +12,15 @@ export default function openUrlRoutes(app: Express, _ctx: ServerContext): void {
     }
 
     // Use the platform's default browser
+    // Windows: "start" needs empty title ("") and windowsHide to suppress cmd flash
+    const quoted = JSON.stringify(url);
     const cmd = process.platform === "darwin"
-      ? "open"
+      ? `open ${quoted}`
       : process.platform === "win32"
-        ? "start"
-        : "xdg-open";
+        ? `start "" ${quoted}`
+        : `xdg-open ${quoted}`;
 
-    exec(`${cmd} ${JSON.stringify(url)}`, (err) => {
+    exec(cmd, { windowsHide: true }, (err) => {
       if (err) console.error("[open-url] Failed to open:", err.message);
     });
 


### PR DESCRIPTION
## Summary
- Fix Windows `start` command by adding empty title `""` so quoted URLs aren't misinterpreted as window titles
- Add `windowsHide: true` to `exec()` to suppress the cmd window flash
- Pre-build the full command string for clarity

## Test plan
- [ ] Open an external URL on Windows — no cmd window flash should appear
- [ ] Open an external URL on macOS/Linux — behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)