### PR TITLE
fix: hard idle cleanup respects active streams

### DIFF
--- a/routes/status.ts
+++ b/routes/status.ts
@@ -120,6 +120,11 @@ export default function statusRoutes(app: Express, ctx: ServerContext): void {
     });
   });
 
+  // Lightweight heartbeat — keeps idle tracker alive (middleware calls touch())
+  app.get("/api/heartbeat", (_req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
   // Pause all other torrents, resume this one
   app.post("/api/set-active/:infoHash", (req: Request, res: Response) => {
     const { infoHash: activeHash } = req.params as Record<string, string>;

--- a/server.ts
+++ b/server.ts
@@ -94,18 +94,30 @@ const idleTracker = createIdleTracker({
     }
   },
   onHardIdle() {
-    // Nuclear option: clear everything
+    // Aggressive cleanup — but respect active streams
     durationCache.clear();
     seekIndexCache.clear();
     seekIndexPending.clear();
     activeFiles.clear();
     availabilityCache.clear();
     tmdbCache.clear();
-    for (const [, st] of streamTracker) { if (st.idleTimer) clearTimeout(st.idleTimer); }
-    streamTracker.clear();
     probeCache.clear();
     introCache.clear();
+    const activeHashes = new Set<string>();
+    for (const [hash, st] of streamTracker) {
+      if (st.count > 0) {
+        activeHashes.add(hash);
+      } else {
+        if (st.idleTimer) clearTimeout(st.idleTimer);
+        streamTracker.delete(hash);
+      }
+    }
     for (const torrent of [...ctx.client.torrents]) {
+      if (activeHashes.has(torrent.infoHash)) {
+        log("info", "Hard idle: keeping actively-streamed torrent", { name: torrent.name });
+        continue;
+      }
+      cleanupTorrentCaches(torrent.infoHash, torrent);
       log("info", "Hard idle: removing torrent", { name: torrent.name });
       torrent.destroy({ destroyStore: false });
     }
@@ -119,7 +131,7 @@ idleTracker.start();
 app.use((req: Request, res: Response, next: NextFunction) => {
   const start = Date.now();
   res.on("finish", () => {
-    if (!req.url.startsWith("/api/status") && !req.url.startsWith("/api/rc/")) {
+    if (!req.url.startsWith("/api/status") && !req.url.startsWith("/api/rc/") && !req.url.startsWith("/api/heartbeat")) {
       log("info", `${req.method} ${req.url} ${res.statusCode} ${Date.now() - start}ms`);
     }
   });

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -277,6 +277,17 @@ export default function Player() {
     return () => { mpvStop(); };
   }, []);
 
+  // Heartbeat: keep the server's idle tracker alive while on the Player page.
+  // useSeek polls /api/status every 1.5s which normally suffices, but Chromium
+  // may throttle timers when the window is backgrounded. A 30s ping with
+  // keepalive ensures the server never considers us idle.
+  useEffect(() => {
+    const timer = setInterval(() => {
+      fetch("/api/heartbeat", { keepalive: true }).catch(() => {});
+    }, 30000);
+    return () => clearInterval(timer);
+  }, []);
+
   // Register command handlers for remote control (assigned every render to avoid stale closures)
   if (commandRef) {
     commandRef.current = {


### PR DESCRIPTION
## Summary
- Hard idle handler now skips torrents with active stream connections (`streamTracker.count > 0`) instead of unconditionally destroying everything
- Calls `cleanupTorrentCaches` before destroying torrents so `completedFiles` gets populated as a disk fallback
- Adds `/api/heartbeat` endpoint and a 30s player heartbeat to keep the idle tracker alive even if Chromium throttles background timers
- Suppresses heartbeat from request logs

## Test plan
- [ ] Play a video, pause, alt-tab away for 10+ minutes, come back — mpv should still be responsive
- [ ] Verify hard idle still cleans up non-streaming torrents and caches
- [ ] Check server logs don't show heartbeat noise