### PR TITLE
fix: prevent webtorrent fallback when debrid mode is always

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -565,6 +565,10 @@ app.post("/api/auto-play", async (req: Request, res: Response) => {
           } satisfies TorrentPlayResult);
         }
       } catch (err) {
+        if (mode === "always") {
+          log("err", "Debrid failed in force-debrid mode, not falling back", { error: (err as Error).message });
+          return res.status(502).json({ error: "debrid_failed" });
+        }
         log("warn", "Debrid failed, falling back to WebTorrent", { error: (err as Error).message });
       }
     }
@@ -704,6 +708,10 @@ app.post("/api/play-torrent", async (req: Request, res: Response) => {
         } satisfies TorrentPlayResult);
       }
     } catch (err) {
+      if (mode === "always") {
+        log("err", "Debrid failed in force-debrid mode, not falling back", { error: (err as Error).message });
+        return res.status(502).json({ error: "debrid_failed" });
+      }
       log("warn", "Debrid failed, falling back to WebTorrent", { error: (err as Error).message });
     }
   }


### PR DESCRIPTION
## Summary

- When debrid mode is set to "always" (force debrid), timeout or failure errors were caught by a generic catch block that silently fell through to WebTorrent
- Both `/api/auto-play` and `/api/play-torrent` endpoints had this bug
- Now checks the mode inside the catch block: if `"always"`, returns a `502 debrid_failed` error instead of falling back to WebTorrent

## Test plan

- [ ] Set debrid mode to "Always use debrid"
- [ ] Play a torrent that isn't cached on debrid — verify it does NOT fall back to WebTorrent
- [ ] Set debrid mode to "Cached only" — verify fallback to WebTorrent still works