### PR TITLE
feat: move My List from home carousel to dedicated navbar page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Home from "./pages/Home";
 import Detail from "./pages/Detail";
 import Player from "./pages/Player";
 import Search from "./pages/Search";
+import MyList from "./pages/MyList";
 import Remote from "./pages/Remote";
 import { getTmdbStatus } from "./lib/api";
 import { setupExternalLinkInterceptor } from "./lib/external-links";
@@ -86,6 +87,7 @@ function AppRoutes() {
           <Route path="/movie/:id" element={<Detail />} />
           <Route path="/tv/:id" element={<Detail />} />
           <Route path="/search" element={<Search />} />
+          <Route path="/my-list" element={<MyList />} />
         </Routes>
         {!isRemote && <MiniPlayer />}
         {isRemote && <RemoteNowPlaying />}

--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -197,6 +197,45 @@
   background: var(--accent-subtle);
 }
 
+.navbar-list-btn {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 16px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: border-color var(--transition-slow), color var(--transition-slow), background var(--transition-slow), text-shadow var(--transition-slow);
+}
+
+.navbar-list-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent-bright);
+  background: var(--accent-subtle);
+}
+
+.navbar-list-btn.active {
+  border-color: var(--accent);
+  color: var(--accent-bright);
+  background: var(--accent-subtle);
+}
+
+.navbar:not(.scrolled) .navbar-list-btn {
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(255, 255, 255, 0.15);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+}
+
+.navbar:not(.scrolled) .navbar-list-btn svg {
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
+}
+
 .navbar-pair-connected {
   display: flex;
   align-items: center;
@@ -239,6 +278,9 @@
     padding: 8px 14px;
   }
   .navbar-pair-btn span {
+    display: none;
+  }
+  .navbar-list-btn span {
     display: none;
   }
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -102,27 +102,33 @@ export default function Navbar() {
             </button>
           )}
           <div className="navbar-actions">
-          <button className="navbar-pair-btn" onClick={() => setShowSettings(true)} title="Settings">
-            <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
-              <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.49.49 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.48.48 0 00-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 00-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1115.6 12 3.6 3.6 0 0112 15.6z" />
-            </svg>
-            Settings
-          </button>
-          <button className="navbar-pair-btn" onClick={() => setShowPairing(true)}>
-            {rcSessionId ? (
-              <span className="navbar-pair-connected">
-                <span className="navbar-pair-dot" />
-                Remote
-              </span>
-            ) : (
-              <>
-                <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
-                  <path d="M17 1H7c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2zm0 18H7V5h10v14z" />
-                </svg>
-                Pair
-              </>
-            )}
-          </button>
+            <Link to="/my-list" className={`navbar-list-btn${location.pathname === "/my-list" ? " active" : ""}`} title="My List">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z" />
+              </svg>
+              <span>My List</span>
+            </Link>
+            <button className="navbar-pair-btn" onClick={() => setShowSettings(true)} title="Settings">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+                <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.49.49 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.48.48 0 00-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 00-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1115.6 12 3.6 3.6 0 0112 15.6z" />
+              </svg>
+              Settings
+            </button>
+              <button className="navbar-pair-btn" onClick={() => setShowPairing(true)}>
+              {rcSessionId ? (
+                <span className="navbar-pair-connected">
+                  <span className="navbar-pair-dot" />
+                  Remote
+                </span>
+              ) : (
+                <>
+                  <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+                    <path d="M17 1H7c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-2-2-2zm0 18H7V5h10v14z" />
+                  </svg>
+                  Pair
+                </>
+              )}
+            </button>
           </div>
         </>
       )}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import HeroSection from "../components/HeroSection";
 import ContentRow from "../components/ContentRow";
 import WatchHistoryRow from "../components/WatchHistoryRow";
-import { fetchTrending, fetchDiscover, fetchGenres, fetchContinueWatching, fetchSavedList, dismissWatchHistory, toggleSaved, autoPlay, poster as posterUrl } from "../lib/api";
+import { fetchTrending, fetchDiscover, fetchGenres, fetchContinueWatching, dismissWatchHistory, autoPlay, poster as posterUrl } from "../lib/api";
 import { waitForBridge, mpvSetPoster, mpvSetTitle, mpvSetLoading, mpvSetLoadingStatus } from "../lib/native-bridge";
 import "./Home.css";
 
@@ -128,11 +128,6 @@ export default function Home() {
         showProgress
         onPlay={handleContinuePlay}
         onRemove={(item) => dismissWatchHistory({ tmdbId: item.tmdbId, mediaType: item.mediaType, season: item.season, episode: item.episode })}
-      />
-      <WatchHistoryRow
-        title="My List"
-        fetchFn={fetchSavedList}
-        onRemove={(item) => toggleSaved({ tmdbId: item.tmdbId, mediaType: item.mediaType, title: item.title, posterPath: item.posterPath }).then(() => {})}
       />
       <ContentRows from={from} to={to} />
     </div>

--- a/src/pages/MyList.css
+++ b/src/pages/MyList.css
@@ -1,0 +1,131 @@
+.my-list-page {
+  min-height: 100vh;
+  padding: 80px 48px 48px;
+}
+
+.my-list-header {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  margin-top: 24px;
+  margin-bottom: 32px;
+}
+
+.my-list-header h1 {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.my-list-count {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.my-list-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 24px 16px;
+}
+
+.my-list-card {
+  cursor: pointer;
+}
+
+.my-list-remove-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.75);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity var(--transition), color var(--transition), background var(--transition);
+  z-index: 3;
+  backdrop-filter: blur(4px);
+  border: none;
+  cursor: pointer;
+}
+
+.my-list-card:hover .my-list-remove-btn {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .my-list-remove-btn {
+    opacity: 0.7;
+  }
+}
+
+.my-list-remove-btn:hover {
+  color: var(--text-primary);
+  background: rgba(251, 113, 133, 0.6);
+}
+
+.my-list-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 24px;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.my-list-empty svg {
+  margin-bottom: 16px;
+  opacity: 0.3;
+}
+
+.my-list-empty p {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin: 0 0 4px;
+}
+
+.my-list-empty span {
+  font-size: 0.9rem;
+  margin-bottom: 24px;
+}
+
+.my-list-browse-btn {
+  padding: 10px 28px;
+  border-radius: 28px;
+  border: 1px solid var(--accent);
+  background: transparent;
+  color: var(--accent-bright);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all var(--transition-slow);
+}
+
+.my-list-browse-btn:hover {
+  background: var(--accent-subtle);
+  border-color: var(--accent-bright);
+}
+
+@media (max-width: 768px) {
+  .my-list-page {
+    padding: 70px 16px 32px;
+  }
+
+  .my-list-header h1 {
+    font-size: 1.5rem;
+  }
+
+  .my-list-grid {
+    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+    gap: 16px 12px;
+  }
+}

--- a/src/pages/MyList.tsx
+++ b/src/pages/MyList.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { poster, fetchSavedList, toggleSaved } from "../lib/api";
+import "./MyList.css";
+
+interface SavedItem {
+  tmdbId: number;
+  mediaType: string;
+  title: string;
+  posterPath: string | null;
+  season?: number;
+  episode?: number;
+  episodeTitle?: string;
+}
+
+export default function MyList() {
+  const navigate = useNavigate();
+  const [items, setItems] = useState<SavedItem[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchSavedList()
+      .then((data) => { if (!cancelled) setItems(data.items || []); })
+      .catch(() => { if (!cancelled) setItems([]); });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const onCleared = () => {
+      fetchSavedList()
+        .then((data) => { if (!cancelled) setItems(data.items || []); })
+        .catch(() => { if (!cancelled) setItems([]); });
+    };
+    window.addEventListener("storage-cleared", onCleared);
+    return () => { cancelled = true; window.removeEventListener("storage-cleared", onCleared); };
+  }, []);
+
+  function handleRemove(item: SavedItem) {
+    setItems((prev) => prev ? prev.filter((i) => i.tmdbId !== item.tmdbId) : prev);
+    toggleSaved({
+      tmdbId: item.tmdbId,
+      mediaType: item.mediaType,
+      title: item.title,
+      posterPath: item.posterPath,
+    }).catch(() => {
+      setItems((prev) => prev ? [...prev, item].sort((a, b) => a.tmdbId - b.tmdbId) : [item]);
+    });
+  }
+
+  return (
+    <div className="my-list-page">
+      <button className="back-btn" onClick={() => navigate(-1)}>
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+          <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
+        </svg>
+        Back
+      </button>
+      <div className="my-list-header">
+        <h1>My List</h1>
+        {items !== null && (
+          <span className="my-list-count">{items.length} {items.length === 1 ? "title" : "titles"}</span>
+        )}
+      </div>
+
+      {items === null ? (
+        <div className="my-list-grid">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <div key={i} className="movie-card">
+              <div className="movie-card-poster skeleton" />
+            </div>
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="my-list-empty">
+          <svg viewBox="0 0 24 24" width="48" height="48" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z" />
+          </svg>
+          <p>Your list is empty</p>
+          <span>Save movies and shows to watch later</span>
+          <button className="my-list-browse-btn" onClick={() => navigate("/")}>
+            Browse
+          </button>
+        </div>
+      ) : (
+        <div className="my-list-grid">
+          {items.map((item) => {
+            const type = item.mediaType || "movie";
+            const img = poster(item.posterPath);
+            return (
+              <div
+                key={`${type}:${item.tmdbId}`}
+                className="movie-card my-list-card"
+                onClick={() => navigate(`/${type}/${item.tmdbId}`)}
+              >
+                <div className="movie-card-poster">
+                  {img ? (
+                    <img src={img} alt={item.title} loading="lazy" />
+                  ) : (
+                    <div className="movie-card-placeholder" />
+                  )}
+                  <button
+                    className="my-list-remove-btn"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRemove(item);
+                    }}
+                    title="Remove from list"
+                  >
+                    <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+                      <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+                    </svg>
+                  </button>
+                </div>
+                <div className="movie-card-info">
+                  <span className="movie-card-title">{item.title}</span>
+                  {type === "tv" && item.season != null && (
+                    <span className="movie-card-year">
+                      S{item.season}E{item.episode}
+                      {item.episodeTitle ? ` \u2014 ${item.episodeTitle}` : ""}
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces the "My List" carousel row on the Home page with a dedicated `/my-list` page
- Adds a "My List" button to the navbar with bookmark icon
- Grid layout with skeleton loading, empty state, and remove-on-hover support
- Cleaned up dead code (unused `savedCount` state, badge CSS)
- Added `SavedItem` TypeScript interface replacing `any` types

## Changes
- **New**: `src/pages/MyList.tsx` — Dedicated page component
- **New**: `src/pages/MyList.css` — Page styles
- **Modified**: `src/App.tsx` — Added `/my-list` route
- **Modified**: `src/components/Navbar.tsx` — Added My List navbar button
- **Modified**: `src/components/Navbar.css` — Navbar button styles
- **Modified**: `src/pages/Home.tsx` — Removed My List carousel