### PR TITLE
fix: make QuickDialogs2 link Windows-only to unbreak Linux

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -7,7 +7,11 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
 # Qt6 modules
-find_package(Qt6 REQUIRED COMPONENTS Quick QuickDialogs2 WebEngineQuick WebChannel Network)
+if(WIN32)
+    find_package(Qt6 REQUIRED COMPONENTS Quick QuickDialogs2 WebEngineQuick WebChannel Network)
+else()
+    find_package(Qt6 REQUIRED COMPONENTS Quick WebEngineQuick WebChannel Network)
+endif()
 
 # libmpv — platform-specific discovery
 if(WIN32)
@@ -46,12 +50,15 @@ add_executable(rattin-shell ${SOURCES})
 
 target_link_libraries(rattin-shell PRIVATE
     Qt6::Quick
-    Qt6::QuickDialogs2
     Qt6::WebEngineQuick
     Qt6::WebChannel
     Qt6::Network
     PkgConfig::MPV
 )
+
+if(WIN32)
+    target_link_libraries(rattin-shell PRIVATE Qt6::QuickDialogs2)
+endif()
 
 if(WIN32)
     target_link_libraries(rattin-shell PRIVATE dwmapi)


### PR DESCRIPTION
## Summary
- `Qt6::QuickDialogs2` was linked globally in `shell/CMakeLists.txt` to fix Windows (windeployqt needs it to bundle the module), but this breaks Linux — the linked library's `prefer :/qt-project.org/imports/QtQuick/Dialogs/` resource path shadows the working filesystem module from `qt6-declarative`
- Make `QuickDialogs2` find_package and target_link_libraries Windows-only

## Test plan
- [ ] Build and run on Linux — `import QtQuick.Dialogs` loads without error
- [ ] Build and run on Windows — FileDialog still works