### PR TITLE
fix: link QuickDialogs2 on all platforms and bundle in AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
             qml6-module-qtquick qml6-module-qtquick-window qml6-module-qtquick-layouts \
             qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtwebchannel \
             qml6-module-qtqml qml6-module-qtqml-models qml6-module-qtqml-workerscript \
-            qml6-module-qtcore \
+            qml6-module-qtcore qml6-module-qtquick-dialogs \
             libfuse2
 
       - uses: actions/setup-node@v4

--- a/install/build-appimage.sh
+++ b/install/build-appimage.sh
@@ -362,7 +362,7 @@ main() {
     qml6-module-qtquick qml6-module-qtquick-window qml6-module-qtquick-layouts \\
     qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtwebchannel \\
     qml6-module-qtqml qml6-module-qtqml-models qml6-module-qtqml-workerscript \\
-    qml6-module-qtcore"
+    qml6-module-qtcore qml6-module-qtquick-dialogs"
     fi
 
     download_tools

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -7,11 +7,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
 # Qt6 modules
-if(WIN32)
-    find_package(Qt6 REQUIRED COMPONENTS Quick QuickDialogs2 WebEngineQuick WebChannel Network)
-else()
-    find_package(Qt6 REQUIRED COMPONENTS Quick WebEngineQuick WebChannel Network)
-endif()
+find_package(Qt6 REQUIRED COMPONENTS Quick QuickDialogs2 WebEngineQuick WebChannel Network)
 
 # libmpv — platform-specific discovery
 if(WIN32)
@@ -50,15 +46,12 @@ add_executable(rattin-shell ${SOURCES})
 
 target_link_libraries(rattin-shell PRIVATE
     Qt6::Quick
+    Qt6::QuickDialogs2
     Qt6::WebEngineQuick
     Qt6::WebChannel
     Qt6::Network
     PkgConfig::MPV
 )
-
-if(WIN32)
-    target_link_libraries(rattin-shell PRIVATE Qt6::QuickDialogs2)
-endif()
 
 if(WIN32)
     target_link_libraries(rattin-shell PRIVATE dwmapi)


### PR DESCRIPTION
## Summary
- Links `Qt6::QuickDialogs2` unconditionally (not Windows-only) so `linuxdeploy-plugin-qt` detects and bundles the QML module
- Adds `qml6-module-qtquick-dialogs` to CI apt packages so the module is available during AppImage build
- Updates build script error message to list the new dependency

Fixes the `module "QtQuick.Dialogs" is not installed` runtime error in Linux AppImages introduced by #39.

## Test plan
- [ ] Linux AppImage launches without `QtQuick.Dialogs` error
- [ ] Subtitle file picker works on Linux
- [ ] Windows build still works (QuickDialogs2 was already linked there)