### PR TITLE
fix: source switcher picks wrong episode during playback

### DIFF
--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -125,7 +125,7 @@ export default function Player() {
     try {
       const result = await playTorrent(
         source.infoHash, source.name,
-        state?.pickerSeason, state?.pickerEpisode,
+        state?.season, state?.episode,
       );
       const newTags = result.tags || source.tags || [];
       setCurrentTags(newTags);


### PR DESCRIPTION
## Summary
- **Bug**: Switching sources mid-episode on the phone remote put the user in a different episode (e.g. watching S2E06 of Andor, switch source, land on wrong episode)
- **Cause**: `handleSwitchSource` passed `state.pickerSeason`/`state.pickerEpisode` to `playTorrent`, but these properties are never set in navigation state — only `state.season`/`state.episode` are. With `undefined` season/episode, the backend picked an arbitrary file from season packs.
- **Fix**: One-line change — use `state.season`/`state.episode` instead

## Test plan
- [ ] Play a TV episode (season pack torrent), open source picker on phone remote, switch to a different source — verify same episode continues
- [ ] Repeat with a non-season-pack torrent to confirm no regression
- [ ] Switch sources on desktop player to confirm no regression there