### PR TITLE
Fix Continue Watching next-episode bug for completed TV series

### DIFF
--- a/lib/storage/watch-history.ts
+++ b/lib/storage/watch-history.ts
@@ -9,6 +9,7 @@ export interface WatchRecord {
   episode?: number;
   episodeTitle?: string;
   seasonEpisodeCount?: number; // total episodes in this season (from TMDB)
+  seasonCount?: number; // total seasons in the series (from TMDB)
   position: number;   // seconds
   duration: number;   // seconds
   finished: boolean;
@@ -34,6 +35,16 @@ function recordKey(mediaType: string, tmdbId: number, season?: number, episode?:
   return `${mediaType}:${tmdbId}`;
 }
 
+function nextEpisodeFrom(record: WatchRecord): { season: number; episode: number } | null {
+  const season = record.season ?? 1;
+  const episode = record.episode ?? 0;
+  const isSeasonFinale = record.seasonEpisodeCount != null && episode >= record.seasonEpisodeCount;
+  if (!isSeasonFinale) return { season, episode: episode + 1 };
+  const isSeriesFinale = record.seasonCount != null && season >= record.seasonCount;
+  if (isSeriesFinale) return null;
+  return { season: season + 1, episode: 1 };
+}
+
 export class WatchHistory {
   constructor(private store: JsonStore<WatchRecord>) {}
 
@@ -42,8 +53,22 @@ export class WatchHistory {
     const existing = this.store.get(key);
     // If duration is unknown (0), preserve the existing duration if we have one
     const duration = record.duration > 0 ? record.duration : (existing?.duration ?? 0);
+    const seasonEpisodeCount = record.seasonEpisodeCount != null
+      ? record.seasonEpisodeCount
+      : existing?.seasonEpisodeCount;
+    const seasonCount = record.seasonCount != null
+      ? record.seasonCount
+      : existing?.seasonCount;
     const finished = duration > 0 && (record.position / duration) >= FINISHED_THRESHOLD;
-    this.store.set(key, { ...record, duration, finished, dismissed: false, updatedAt: new Date().toISOString() });
+    this.store.set(key, {
+      ...record,
+      duration,
+      seasonEpisodeCount,
+      seasonCount,
+      finished,
+      dismissed: false,
+      updatedAt: new Date().toISOString(),
+    });
   }
 
   getProgress(mediaType: string, tmdbId: number, season?: number, episode?: number): WatchRecord | undefined {
@@ -80,12 +105,12 @@ export class WatchHistory {
         });
         const last = sorted[sorted.length - 1];
         if (last.dismissed) continue;
-        const lastEp = last.episode ?? 0;
-        const isSeasonFinale = last.seasonEpisodeCount != null && lastEp >= last.seasonEpisodeCount;
+        const next = nextEpisodeFrom(last);
+        if (!next) continue;
         nextUp.push({
           ...last,
-          season: isSeasonFinale ? (last.season ?? 1) + 1 : (last.season ?? 1),
-          episode: isSeasonFinale ? 1 : lastEp + 1,
+          season: next.season,
+          episode: next.episode,
           position: 0,
           duration: 0,
           finished: false,
@@ -156,11 +181,11 @@ export class WatchHistory {
 
     // All recorded episodes are finished — suggest the next one after the last in order
     const last = episodes[episodes.length - 1];
-    const lastEp = last.episode ?? 0;
-    const isSeasonFinale = last.seasonEpisodeCount != null && lastEp >= last.seasonEpisodeCount;
+    const next = nextEpisodeFrom(last);
+    if (!next) return null;
     return {
-      season: isSeasonFinale ? (last.season ?? 1) + 1 : (last.season ?? 1),
-      episode: isSeasonFinale ? 1 : lastEp + 1,
+      season: next.season,
+      episode: next.episode,
       position: 0,
     };
   }
@@ -169,7 +194,22 @@ export class WatchHistory {
   dismiss(mediaType: string, tmdbId: number, season?: number, episode?: number): void {
     const key = recordKey(mediaType, tmdbId, season, episode);
     const record = this.store.get(key);
-    if (record) this.store.set(key, { ...record, dismissed: true });
+    if (record) {
+      this.store.set(key, { ...record, dismissed: true });
+      return;
+    }
+
+    // Synthetic TV "next up" entries have no direct backing record key.
+    // If the dismissed item matches the computed next episode from the last
+    // finished record, dismiss that source record so the synthetic row stays hidden.
+    if (mediaType !== "tv" || season == null || episode == null) return;
+    const episodes = this.getSeriesProgress(tmdbId);
+    if (episodes.length === 0 || episodes.some((e) => !e.finished)) return;
+    const last = episodes[episodes.length - 1];
+    const next = nextEpisodeFrom(last);
+    if (!next || next.season !== season || next.episode !== episode) return;
+    const lastKey = recordKey("tv", tmdbId, last.season, last.episode);
+    this.store.set(lastKey, { ...last, dismissed: true });
   }
 
   get size(): number { return this.store.size; }

--- a/routes/storage.ts
+++ b/routes/storage.ts
@@ -20,7 +20,7 @@ export default function storageRoutes(app: Express, ctx: ServerContext): void {
 
   // Accept both PUT (normal) and POST (sync XHR on unmount)
   function handleProgress(req: Request, res: Response) {
-    const { tmdbId, mediaType, title, posterPath, season, episode, episodeTitle, seasonEpisodeCount, position, duration, imdbId, year } = req.body;
+    const { tmdbId, mediaType, title, posterPath, season, episode, episodeTitle, seasonEpisodeCount, seasonCount, position, duration, imdbId, year } = req.body;
     if (!tmdbId || !mediaType || !title || position == null) {
       res.status(400).json({ error: "missing_fields" });
       return;
@@ -44,6 +44,7 @@ export default function storageRoutes(app: Express, ctx: ServerContext): void {
       episode: episode != null ? Number(episode) : undefined,
       episodeTitle: episodeTitle ?? undefined,
       seasonEpisodeCount: seasonEpisodeCount != null ? Number(seasonEpisodeCount) : undefined,
+      seasonCount: seasonCount != null ? Number(seasonCount) : undefined,
       position: pos,
       duration: dur,
       finished: false, // computed by recordProgress

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -251,7 +251,7 @@ export async function deleteTmdbConfig(): Promise<void> {
 
 export async function reportWatchProgress(data: {
   tmdbId: number; mediaType: string; title: string; posterPath: string | null;
-  season?: number; episode?: number; episodeTitle?: string; seasonEpisodeCount?: number;
+  season?: number; episode?: number; episodeTitle?: string; seasonEpisodeCount?: number; seasonCount?: number;
   position: number; duration: number;
   imdbId?: string; year?: number;
 }): Promise<void> {

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -484,6 +484,7 @@ export default function Detail() {
                               episode: ep.episode_number,
                               episodeTitle: ep.name,
                               seasonEpisodeCount: episodes?.episodes?.length,
+                              seasonCount: seasons?.length,
                               position: nowFinished ? dur : 0,
                               duration: dur,
                             }).then(() => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -93,6 +93,7 @@ export default function Home() {
             year: item.year, type: item.mediaType, season: item.season, episode: item.episode,
             imdbId: item.imdbId, tmdbId: item.tmdbId, posterPath: item.posterPath,
             episodeTitle: item.episodeTitle, seasonEpisodeCount: item.seasonEpisodeCount,
+            seasonCount: item.seasonCount,
             resumePosition: item.position > 0 ? item.position : undefined,
           },
         }),
@@ -116,6 +117,7 @@ export default function Home() {
       episode: item.episode,
       episodeTitle: item.episodeTitle,
       seasonEpisodeCount: item.seasonEpisodeCount,
+      seasonCount: item.seasonCount,
       resumePosition: item.position > 0 ? item.position : undefined,
     };
     if (result.debridStreamKey) navState.debridStreamKey = result.debridStreamKey;

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -266,6 +266,7 @@ export default function Player() {
         tmdbId: state.tmdbId, year, type: "tv", imdbId, posterPath: state.posterPath ?? null,
         season: nextSeason, episode: nextEpisode,
         episodeTitle, seasonEpisodeCount,
+        seasonCount: state.seasonCount != null ? Number(state.seasonCount) : undefined,
       };
       if (result.debridStreamKey) navState.debridStreamKey = result.debridStreamKey;
       navigate(`/play/${result.infoHash}/${result.fileIndex}`, { state: navState });
@@ -514,6 +515,7 @@ export default function Player() {
       episode: state.episode != null ? Number(state.episode) : undefined,
       episodeTitle: state.episodeTitle ?? undefined,
       seasonEpisodeCount: state.seasonEpisodeCount != null ? Number(state.seasonEpisodeCount) : undefined,
+      seasonCount: state.seasonCount != null ? Number(state.seasonCount) : undefined,
       position: pos,
       duration: dur,
       imdbId: state.imdbId ?? undefined,
@@ -541,6 +543,7 @@ export default function Player() {
       episode: state.episode != null ? Number(state.episode) : undefined,
       episodeTitle: state.episodeTitle ?? undefined,
       seasonEpisodeCount: state.seasonEpisodeCount != null ? Number(state.seasonEpisodeCount) : undefined,
+      seasonCount: state.seasonCount != null ? Number(state.seasonCount) : undefined,
       position: pos,
       duration: Math.floor(time.duration),
       imdbId: state.imdbId ?? undefined,
@@ -582,6 +585,7 @@ export default function Player() {
       episode: state.episode != null ? Number(state.episode) : undefined,
       episodeTitle: state.episodeTitle ?? undefined,
       seasonEpisodeCount: state.seasonEpisodeCount != null ? Number(state.seasonEpisodeCount) : undefined,
+      seasonCount: state.seasonCount != null ? Number(state.seasonCount) : undefined,
       position: 0,
       duration: 0,
       imdbId: state.imdbId ?? undefined,

--- a/test/lib/storage/watch-history.test.ts
+++ b/test/lib/storage/watch-history.test.ts
@@ -154,6 +154,20 @@ describe("WatchHistory.getContinueWatching", () => {
     assert.ok(!items.find((i) => i.tmdbId === 50));
   });
 
+  it("does not include 'next up' past known final season", () => {
+    wh.recordProgress(makeRecord({
+      tmdbId: 51,
+      season: 2,
+      episode: 10,
+      seasonEpisodeCount: 10,
+      seasonCount: 2,
+      position: 2400,
+      duration: 2400,
+    }));
+    const items = wh.getContinueWatching().filter((i) => i.tmdbId === 51);
+    assert.equal(items.length, 0);
+  });
+
   it("limits to 20 items", () => {
     for (let i = 1; i <= 25; i++) {
       wh.recordProgress(makeRecord({ tmdbId: i, episode: i, position: 600 }));
@@ -188,6 +202,19 @@ describe("WatchHistory.getResumePoint", () => {
     assert.equal(rp.season, 1);
     assert.equal(rp.episode, 4);
     assert.equal(rp.position, 0);
+  });
+
+  it("returns null when all recorded are finished at known series finale", () => {
+    wh.recordProgress(makeRecord({
+      tmdbId: 11,
+      season: 3,
+      episode: 8,
+      seasonEpisodeCount: 8,
+      seasonCount: 3,
+      position: 2400,
+      duration: 2400,
+    }));
+    assert.equal(wh.getResumePoint(11, "tv"), null);
   });
 
   it("resumes most recent unfinished even if earlier episodes are also unfinished", async () => {
@@ -296,6 +323,20 @@ describe("WatchHistory.dismiss", () => {
     assert.equal(wh.getProgress("tv", 10, 1, 1)!.dismissed, true);
     // Episode 2 should not be dismissed (dismissed is false because recordProgress sets it)
     assert.equal(wh.getProgress("tv", 10, 1, 2)!.dismissed, false);
+  });
+
+  it("dismisses synthetic next-up items by marking source episode dismissed", () => {
+    wh.recordProgress(makeRecord({ tmdbId: 12, episode: 1, position: 2400, duration: 2400 }));
+    wh.recordProgress(makeRecord({ tmdbId: 12, episode: 2, position: 2400, duration: 2400 }));
+    const before = wh.getContinueWatching().find((i) => i.tmdbId === 12);
+    assert.ok(before);
+    assert.equal(before!.episode, 3);
+
+    wh.dismiss("tv", 12, 1, 3);
+
+    const after = wh.getContinueWatching().find((i) => i.tmdbId === 12);
+    assert.equal(after, undefined);
+    assert.equal(wh.getProgress("tv", 12, 1, 2)?.dismissed, true);
   });
 
   it("no-op for nonexistent record", () => {

--- a/test/routes/storage.test.ts
+++ b/test/routes/storage.test.ts
@@ -175,6 +175,40 @@ describe("Storage routes", () => {
       const spBody = await spRes.json() as { episodes: Array<{ episode: number; position: number }> };
       assert.ok(spBody.episodes.some((e) => e.episode === 1 && e.position === 600));
     });
+
+    it("dismisses synthetic next-up entries for completed TV progress", async () => {
+      await fetch(`${baseUrl}/api/watch-history/progress`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tmdbId: 501, mediaType: "tv", title: "Synthetic Dismiss Test",
+          posterPath: null, season: 1, episode: 1, position: 2400, duration: 2400,
+        }),
+      });
+      await fetch(`${baseUrl}/api/watch-history/progress`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tmdbId: 501, mediaType: "tv", title: "Synthetic Dismiss Test",
+          posterPath: null, season: 1, episode: 2, position: 2400, duration: 2400,
+        }),
+      });
+
+      const beforeRes = await fetch(`${baseUrl}/api/watch-history/continue`);
+      const before = await beforeRes.json() as { items: Array<{ tmdbId: number; season?: number; episode?: number }> };
+      assert.ok(before.items.some((i) => i.tmdbId === 501 && i.season === 1 && i.episode === 3));
+
+      const dismissRes = await fetch(`${baseUrl}/api/watch-history/dismiss`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tmdbId: 501, mediaType: "tv", season: 1, episode: 3 }),
+      });
+      assert.equal(dismissRes.status, 200);
+
+      const afterRes = await fetch(`${baseUrl}/api/watch-history/continue`);
+      const after = await afterRes.json() as { items: Array<{ tmdbId: number }> };
+      assert.ok(!after.items.some((i) => i.tmdbId === 501));
+    });
   });
 
   // ── Saved List ─────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes Continue Watching suggesting a non-existent next season episode after the
  series finale. Also makes dismiss persist for synthetic next-up entries and adds
  regression tests.