### PR TITLE
Fix AppImage GLIBC 2.38 incompatibility with Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,26 @@ permissions:
   contents: write
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
   build-linux:
+    needs: [validate]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +68,7 @@ jobs:
           path: Rattin-x86_64.AppImage
 
   build-windows:
+    needs: [validate]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +111,15 @@ jobs:
       - name: Download Node.js binary
         shell: pwsh
         run: |
-          Invoke-WebRequest -Uri "https://nodejs.org/dist/v20.18.1/node-v20.18.1-win-x64.zip" -OutFile node.zip
+          $nodeVer = "20.18.1"
+          Invoke-WebRequest -Uri "https://nodejs.org/dist/v$nodeVer/node-v$nodeVer-win-x64.zip" -OutFile node.zip
+          Invoke-WebRequest -Uri "https://nodejs.org/dist/v$nodeVer/SHASUMS256.txt" -OutFile node-shasums.txt
+          $expected = (Get-Content node-shasums.txt | Select-String "node-v$nodeVer-win-x64.zip").ToString().Split(" ")[0]
+          $actual = (Get-FileHash node.zip -Algorithm SHA256).Hash.ToLower()
+          if ($expected -ne $actual) {
+              throw "Node.js checksum mismatch! Expected: $expected Got: $actual"
+          }
+          Write-Host "Node.js checksum verified: $actual"
           Expand-Archive node.zip -DestinationPath node-build -Force
 
       - name: Build frontend
@@ -171,6 +199,88 @@ jobs:
           & "$env:GITHUB_WORKSPACE/$dist/rattin-runtime.exe" "$($nodeDir.FullName)/node_modules/npm/bin/npm-cli.js" ci --omit=dev
           Pop-Location
 
+      - name: Verify distribution
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $dist = "Rattin"
+          $app  = "$dist/app"
+          $errors = 0
+
+          # Core binaries
+          foreach ($bin in @("rattin-shell.exe", "rattin-runtime.exe", "libmpv-2.dll")) {
+              if (-not (Test-Path "$dist/$bin")) {
+                  Write-Error "Missing binary: $bin"
+                  $errors++
+              }
+          }
+
+          # VC++ runtime
+          foreach ($dll in @("vcruntime140.dll", "msvcp140.dll")) {
+              if (-not (Test-Path "$dist/$dll")) {
+                  Write-Error "Missing VC++ runtime: $dll"
+                  $errors++
+              }
+          }
+
+          # Qt DLLs
+          foreach ($qt in @("Qt6Core.dll", "Qt6Gui.dll", "Qt6Quick.dll",
+                            "Qt6WebEngineCore.dll", "Qt6Network.dll", "Qt6WebChannel.dll")) {
+              if (-not (Test-Path "$dist/$qt")) {
+                  Write-Error "Missing Qt DLL: $qt"
+                  $errors++
+              }
+          }
+
+          # QtWebEngineProcess
+          if (-not (Test-Path "$dist/QtWebEngineProcess.exe")) {
+              Write-Error "Missing QtWebEngineProcess.exe"
+              $errors++
+          }
+
+          # Server bundle
+          $serverJs = "$app/server.js"
+          if (-not (Test-Path $serverJs)) {
+              Write-Error "Missing server.js bundle"
+              $errors++
+          } else {
+              $size = (Get-Item $serverJs).Length
+              if ($size -lt 10000) {
+                  Write-Error "server.js suspiciously small ($size bytes)"
+                  $errors++
+              }
+              & "$dist/rattin-runtime.exe" --check $serverJs
+              if ($LASTEXITCODE -ne 0) {
+                  Write-Error "server.js has syntax errors"
+                  $errors++
+              }
+          }
+
+          # Frontend assets
+          if (-not (Test-Path "$app/public/index.html")) {
+              Write-Error "Missing frontend: public/index.html"
+              $errors++
+          }
+          if (-not (Get-ChildItem "$app/public/assets" -Filter "*.js" -ErrorAction SilentlyContinue)) {
+              Write-Error "Missing frontend JS assets"
+              $errors++
+          }
+          if (-not (Get-ChildItem "$app/public/assets" -Filter "*.css" -ErrorAction SilentlyContinue)) {
+              Write-Error "Missing frontend CSS assets"
+              $errors++
+          }
+
+          # node_modules
+          if (-not (Test-Path "$app/node_modules")) {
+              Write-Error "Missing node_modules"
+              $errors++
+          }
+
+          if ($errors -gt 0) {
+              throw "Distribution verification failed with $errors error(s)"
+          }
+          Write-Host "Distribution verification passed" -ForegroundColor Green
+
       - name: Create portable ZIP
         shell: pwsh
         run: Compress-Archive -Path Rattin -DestinationPath Rattin-x64-Portable.zip
@@ -220,6 +330,48 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
 
+      - name: Verify artifact sizes
+        run: |
+          set -euo pipefail
+          errors=0
+
+          check_size() {
+            local file="$1" min_mb="$2" label="$3"
+            if [ ! -f "$file" ]; then
+              echo "::error::Missing artifact: $label ($file)"
+              errors=$((errors + 1))
+              return
+            fi
+            local size_bytes
+            size_bytes=$(stat -c%s "$file")
+            local size_mb=$((size_bytes / 1048576))
+            if [ "$size_bytes" -lt $((min_mb * 1048576)) ]; then
+              echo "::error::$label is only ${size_mb}MB (minimum: ${min_mb}MB) — likely corrupt or incomplete"
+              errors=$((errors + 1))
+            else
+              echo "$label: ${size_mb}MB ✓"
+            fi
+          }
+
+          check_size "Rattin-x86_64.AppImage/Rattin-x86_64.AppImage" 100 "Linux AppImage"
+          check_size "Rattin-x64-Portable.zip/Rattin-x64-Portable.zip" 100 "Windows Portable ZIP"
+          check_size "Rattin-x64-Setup.exe/Rattin-x64-Setup.exe" 50 "Windows Installer"
+
+          if [ "$errors" -gt 0 ]; then
+            echo "::error::Artifact size verification failed with $errors error(s)"
+            exit 1
+          fi
+
+      - name: Generate checksums
+        run: |
+          sha256sum \
+            Rattin-x86_64.AppImage/Rattin-x86_64.AppImage \
+            Rattin-x64-Portable.zip/Rattin-x64-Portable.zip \
+            Rattin-x64-Setup.exe/Rattin-x64-Setup.exe \
+            | sed 's|[^ ]*/||' > SHA256SUMS.txt
+          echo "Checksums:"
+          cat SHA256SUMS.txt
+
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -235,4 +387,5 @@ jobs:
             $PRERELEASE \
             Rattin-x86_64.AppImage/Rattin-x86_64.AppImage \
             Rattin-x64-Portable.zip/Rattin-x64-Portable.zip \
-            Rattin-x64-Setup.exe/Rattin-x64-Setup.exe
+            Rattin-x64-Setup.exe/Rattin-x64-Setup.exe \
+            SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           version: '6.7.3'
           host: linux
           target: desktop
-          modules: qtwebengine qtwebchannel qtpositioning
+          modules: qtwebengine qtwebchannel qtpositioning qtserialport
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -18,15 +18,18 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            cmake g++ \
-            qt6-base-dev qt6-webengine-dev qt6-declarative-dev qt6-webchannel-dev \
+            cmake g++ pkg-config \
             libmpv-dev patchelf libjack-jackd2-0 \
-            qml6-module-qtwebengine qml6-module-qtwebengine-controlsdelegates \
-            qml6-module-qtquick qml6-module-qtquick-window qml6-module-qtquick-layouts \
-            qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtwebchannel \
-            qml6-module-qtqml qml6-module-qtqml-models qml6-module-qtqml-workerscript \
-            qml6-module-qtcore qml6-module-qtquick-dialogs qml6-module-qt-labs-folderlistmodel \
+            libgl1-mesa-dev libxkbcommon-dev \
             libfuse2
+
+      - name: Install Qt6
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.7.3'
+          host: linux
+          target: desktop
+          modules: qtwebengine qtwebchannel qtpositioning qtwayland
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,62 @@ jobs:
       - name: Build AppImage
         run: bash install/build-appimage.sh --clean
 
+      - name: Smoke test AppImage
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y xvfb
+          chmod +x Rattin-x86_64.AppImage
+          export APPIMAGE_EXTRACT_AND_RUN=1
+
+          # Start the app with a virtual display and capture all output
+          xvfb-run --auto-servernum ./Rattin-x86_64.AppImage &> /tmp/smoke.log &
+          APP_PID=$!
+
+          # Wait up to 30s for the server to start
+          started=false
+          for i in $(seq 1 30); do
+            if grep -q "Rattin running at" /tmp/smoke.log 2>/dev/null; then
+              started=true
+              break
+            fi
+            if ! kill -0 "$APP_PID" 2>/dev/null; then
+              echo "::error::App crashed during startup"
+              cat /tmp/smoke.log
+              exit 1
+            fi
+            sleep 1
+          done
+
+          if [ "$started" != "true" ]; then
+            echo "::error::Server did not start within 30s"
+            cat /tmp/smoke.log
+            kill "$APP_PID" 2>/dev/null || true
+            exit 1
+          fi
+          echo "Server started"
+
+          # Verify HTTP response
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9630 || true)
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Server responded with HTTP $HTTP_CODE (expected 200)"
+            cat /tmp/smoke.log
+            kill "$APP_PID" 2>/dev/null || true
+            exit 1
+          fi
+          echo "HTTP 200 OK"
+
+          # Check for known failure patterns in logs
+          if grep -qiE "(Cannot load library|module not found|FATAL|Segmentation fault|SIGABRT|SIGILL)" /tmp/smoke.log; then
+            echo "::error::Found error patterns in startup logs:"
+            grep -iE "(Cannot load library|module not found|FATAL|Segmentation fault|SIGABRT|SIGILL)" /tmp/smoke.log
+            kill "$APP_PID" 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "Smoke test passed"
+          kill "$APP_PID" 2>/dev/null || true
+          wait "$APP_PID" 2>/dev/null || true
+
       - name: Upload AppImage
         uses: actions/upload-artifact@v4
         with:
@@ -310,6 +366,77 @@ jobs:
             /DOUTPUT="$output" `
             /X"!addplugindir /x86-unicode $pluginDir\x86-unicode" `
             packaging/windows/rattin.nsi
+
+      - name: Smoke test distribution
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $dist = "$env:GITHUB_WORKSPACE/Rattin"
+          $logFile = "$env:TEMP/smoke.log"
+
+          # Start the app and capture output
+          $proc = Start-Process -FilePath "$dist/rattin-shell.exe" `
+            -RedirectStandardOutput $logFile `
+            -RedirectStandardError "$env:TEMP/smoke-err.log" `
+            -PassThru
+
+          # Wait up to 30s for server to start
+          $started = $false
+          for ($i = 1; $i -le 30; $i++) {
+              Start-Sleep -Seconds 1
+              if ($proc.HasExited) {
+                  Write-Error "App crashed during startup (exit code: $($proc.ExitCode))"
+                  Get-Content $logFile -ErrorAction SilentlyContinue
+                  Get-Content "$env:TEMP/smoke-err.log" -ErrorAction SilentlyContinue
+                  exit 1
+              }
+              $logs = ""
+              if (Test-Path $logFile) { $logs += Get-Content $logFile -Raw -ErrorAction SilentlyContinue }
+              if (Test-Path "$env:TEMP/smoke-err.log") { $logs += Get-Content "$env:TEMP/smoke-err.log" -Raw -ErrorAction SilentlyContinue }
+              if ($logs -match "Rattin running at") {
+                  $started = $true
+                  break
+              }
+          }
+
+          if (-not $started) {
+              Write-Error "Server did not start within 30s"
+              Get-Content $logFile -ErrorAction SilentlyContinue
+              Get-Content "$env:TEMP/smoke-err.log" -ErrorAction SilentlyContinue
+              Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+              exit 1
+          }
+          Write-Host "Server started"
+
+          # Verify HTTP response
+          try {
+              $response = Invoke-WebRequest -Uri "http://127.0.0.1:9630" -UseBasicParsing -TimeoutSec 10
+              if ($response.StatusCode -ne 200) {
+                  Write-Error "Server responded with HTTP $($response.StatusCode)"
+                  Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+                  exit 1
+              }
+              Write-Host "HTTP 200 OK"
+          } catch {
+              Write-Error "HTTP request failed: $_"
+              Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+              exit 1
+          }
+
+          # Check for error patterns
+          $allLogs = ""
+          if (Test-Path $logFile) { $allLogs += Get-Content $logFile -Raw -ErrorAction SilentlyContinue }
+          if (Test-Path "$env:TEMP/smoke-err.log") { $allLogs += Get-Content "$env:TEMP/smoke-err.log" -Raw -ErrorAction SilentlyContinue }
+          $errorPatterns = "Cannot load library|module not found|FATAL|SIGABRT"
+          if ($allLogs -match $errorPatterns) {
+              Write-Error "Found error patterns in startup logs"
+              Write-Host $allLogs
+              Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+              exit 1
+          }
+
+          Write-Host "Smoke test passed"
+          Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
 
       - name: Upload portable ZIP
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           version: '6.7.3'
           host: linux
           target: desktop
-          modules: qtwebengine qtwebchannel qtpositioning qtwayland
+          modules: qtwebengine qtwebchannel qtpositioning
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          sudo apt-get update && sudo apt-get install -y ffmpeg
+          npm ci
 
       - name: Type-check
         run: npm run typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
             cmake g++ pkg-config \
             libmpv-dev patchelf libjack-jackd2-0 \
             libgl1-mesa-dev libxkbcommon-dev \
+            libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 libxcb-shape0 \
+            libxcb-xinerama0 libxcb-xkb1 libxcb-randr0 libxcb-render-util0 \
+            libxcb-image0 libxcb-xfixes0 libxcb-sync1 libxcb-glx0 \
+            libwayland-cursor0 libwayland-egl1 libegl1 \
             libfuse2
 
       - name: Install Qt6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Type-check
         run: npm run typecheck
 
+      - name: Build frontend
+        run: npm run build
+
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,9 +174,15 @@ jobs:
       - name: Install NSIS
         shell: pwsh
         run: |
-          $url = "https://sourceforge.net/projects/nsis/files/NSIS%203/3.10/nsis-3.10-setup.exe/download"
-          Invoke-WebRequest -Uri $url -OutFile nsis-setup.exe -MaximumRedirection 5
-          Start-Process -FilePath .\nsis-setup.exe -ArgumentList '/S' -Wait
+          for ($i = 1; $i -le 3; $i++) {
+              choco install nsis -y 2>&1
+              if (Test-Path "C:\Program Files (x86)\NSIS\makensis.exe") { break }
+              Write-Host "NSIS not found after attempt $i, retrying in 15s..."
+              Start-Sleep -Seconds 15
+          }
+          if (-not (Test-Path "C:\Program Files (x86)\NSIS\makensis.exe")) {
+              throw "Failed to install NSIS after 3 attempts"
+          }
 
       - name: Build NSIS installer
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,10 @@ jobs:
 
       - name: Install NSIS
         shell: pwsh
-        run: choco install nsis -y
+        run: |
+          $url = "https://sourceforge.net/projects/nsis/files/NSIS%203/3.10/nsis-3.10-setup.exe/download"
+          Invoke-WebRequest -Uri $url -OutFile nsis-setup.exe -MaximumRedirection 5
+          Start-Process -FilePath .\nsis-setup.exe -ArgumentList '/S' -Wait
 
       - name: Build NSIS installer
         shell: pwsh

--- a/install/AppRun
+++ b/install/AppRun
@@ -6,6 +6,24 @@
 
 HERE="$(dirname "$(readlink -f "$0")")"
 
+# ── App directories ─────────────────────────────────────────────────────────
+export MAGNET_APP_DIR="$HERE/usr/share/rattin/app/"
+export MAGNET_NODE_PATH="$HERE/usr/share/rattin/node/bin/node"
+
+# ── Config setup (before LD_LIBRARY_PATH so system commands use host libs) ──
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/rattin"
+export MAGNET_CONFIG_DIR="$CONFIG_DIR"
+mkdir -p "$CONFIG_DIR"
+
+# First-run: create .env from bundled example
+if [ ! -f "$CONFIG_DIR/.env" ]; then
+    if [ -f "$MAGNET_APP_DIR/.env.example" ]; then
+        cp "$MAGNET_APP_DIR/.env.example" "$CONFIG_DIR/.env"
+    else
+        echo "TMDB_API_KEY=" > "$CONFIG_DIR/.env"
+    fi
+fi
+
 # ── Library paths (Qt6, libmpv, codecs) ──────────────────────────────────────
 export LD_LIBRARY_PATH="$HERE/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
@@ -20,23 +38,5 @@ export QTWEBENGINE_CHROMIUM_FLAGS="${QTWEBENGINE_CHROMIUM_FLAGS:+$QTWEBENGINE_CH
 
 # ── PATH — bundled node, ffmpeg, ffprobe ─────────────────────────────────────
 export PATH="$HERE/usr/share/rattin/node/bin:$HERE/usr/bin:$PATH"
-
-# ── App directories ─────────────────────────────────────────────────────────
-export MAGNET_APP_DIR="$HERE/usr/share/rattin/app/"
-export MAGNET_NODE_PATH="$HERE/usr/share/rattin/node/bin/node"
-
-# Writable config directory (outside the read-only AppImage mount)
-CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/rattin"
-export MAGNET_CONFIG_DIR="$CONFIG_DIR"
-mkdir -p "$CONFIG_DIR"
-
-# First-run: create .env from bundled example
-if [ ! -f "$CONFIG_DIR/.env" ]; then
-    if [ -f "$MAGNET_APP_DIR/.env.example" ]; then
-        cp "$MAGNET_APP_DIR/.env.example" "$CONFIG_DIR/.env"
-    else
-        echo "TMDB_API_KEY=" > "$CONFIG_DIR/.env"
-    fi
-fi
 
 exec "$HERE/usr/bin/rattin-shell" "$@"

--- a/install/build-appimage.sh
+++ b/install/build-appimage.sh
@@ -319,6 +319,9 @@ build_appimage() {
     rm -f "$APPDIR"/usr/lib/libsmime3.so*
     rm -f "$APPDIR"/usr/lib/libssl3.so*
 
+    # ── Verify AppDir before packaging ─────────────────────────────────────
+    verify_appdir
+
     # Now produce the AppImage
     log "Packaging AppImage..."
 
@@ -335,6 +338,85 @@ build_appimage() {
     local size
     size="$(du -h "$OUTPUT" | cut -f1)"
     log "AppImage ready: $OUTPUT ($size)"
+}
+
+# ---------------------------------------------------------------------------
+# Verify AppDir — catch missing plugins/libs before packaging
+# ---------------------------------------------------------------------------
+verify_appdir() {
+    log "Verifying AppDir contents..."
+    local errors=0
+
+    # Platform plugins (at least xcb is required; wayland for modern desktops)
+    for plugin in libqxcb.so; do
+        if [ ! -f "$APPDIR/usr/plugins/platforms/$plugin" ]; then
+            err "Missing required platform plugin: $plugin"
+            ((errors++))
+        fi
+    done
+    # Wayland is non-fatal but warn loudly
+    if ! ls "$APPDIR"/usr/plugins/platforms/libqwayland*.so >/dev/null 2>&1; then
+        warn "No Wayland platform plugins found — Wayland-only desktops will fall back to XWayland"
+    fi
+
+    # Qt libraries
+    for lib in libQt6Core.so.6 libQt6Gui.so.6 libQt6Quick.so.6 \
+               libQt6WebEngineCore.so.6 libQt6Network.so.6 libQt6WebChannel.so.6; do
+        if ! ls "$APPDIR/usr/lib/$lib"* >/dev/null 2>&1; then
+            err "Missing Qt library: $lib"
+            ((errors++))
+        fi
+    done
+
+    # QML modules
+    for mod in QtWebEngine QtQuick; do
+        if [ ! -d "$APPDIR/usr/qml/$mod" ]; then
+            err "Missing QML module: $mod"
+            ((errors++))
+        fi
+    done
+
+    # Binaries
+    for bin in rattin-shell ffmpeg ffprobe; do
+        if [ ! -x "$APPDIR/usr/bin/$bin" ]; then
+            err "Missing binary: $bin"
+            ((errors++))
+        fi
+    done
+
+    # Node.js runtime
+    if [ ! -x "$APPDIR/usr/share/rattin/node/bin/node" ]; then
+        err "Missing Node.js runtime"
+        ((errors++))
+    fi
+
+    # GLIBC version check — ensure all bundled libs work on target distros
+    local max_glibc_target="2.35"
+    local max_glibc
+    max_glibc=$(find "$APPDIR" -type f \( -name '*.so' -o -name '*.so.*' \) \
+        -exec readelf -V {} \; 2>/dev/null \
+        | grep -oP 'GLIBC_\K[0-9.]+' | sort -V -u | tail -1)
+    if [ -n "$max_glibc" ]; then
+        # Check if max_glibc > max_glibc_target
+        local highest
+        highest="$(printf '%s\n%s' "$max_glibc" "$max_glibc_target" | sort -V | tail -1)"
+        if [ "$highest" != "$max_glibc_target" ]; then
+            err "Bundled libraries require GLIBC $max_glibc (target: ≤$max_glibc_target)"
+            err "Offending libraries:"
+            find "$APPDIR" -type f \( -name '*.so' -o -name '*.so.*' \) -exec sh -c '
+                readelf -V "$1" 2>/dev/null | grep -q "GLIBC_'"$max_glibc"'" && printf "  → %s\n" "$1"
+            ' _ {} \;
+            ((errors++))
+        else
+            log "GLIBC check passed (max: ${max_glibc}, target: ≤${max_glibc_target})"
+        fi
+    fi
+
+    if [ "$errors" -gt 0 ]; then
+        die "AppDir verification failed with $errors error(s) — refusing to package broken AppImage"
+    fi
+
+    log "AppDir verification passed"
 }
 
 # ---------------------------------------------------------------------------

--- a/install/build-appimage.sh
+++ b/install/build-appimage.sh
@@ -266,6 +266,10 @@ build_appimage() {
     # Don't produce AppImage yet — we need to strip problematic libs first.
     # Disable strip — linuxdeploy's bundled strip is too old for .relr.dyn sections
     # on newer distros (Arch, Fedora 40+, etc.), causing spurious failures.
+    # NOTE: linuxdeploy may exit non-zero even on partial success (known quirk),
+    # so we capture the exit code and warn rather than abort. The verify_appdir()
+    # step below will catch any real missing-library consequences.
+    local ld_exit=0
     DISABLE_COPYRIGHT_FILES_DEPLOYMENT=1 "$TOOLS_DIR/linuxdeploy" \
         --appdir "$APPDIR" \
         --executable "$APPDIR/usr/bin/rattin-shell" \
@@ -273,7 +277,10 @@ build_appimage() {
         --icon-file "$APPDIR/rattin.svg" \
         --custom-apprun "$REPO_ROOT/install/AppRun" \
         --plugin qt \
-        || true
+        || ld_exit=$?
+    if [ "$ld_exit" -ne 0 ]; then
+        warn "linuxdeploy exited with code $ld_exit — verify_appdir will check for consequences"
+    fi
 
     # linuxdeploy --custom-apprun is unreliable — copy manually
     cp "$REPO_ROOT/install/AppRun" "$APPDIR/AppRun"
@@ -368,6 +375,12 @@ verify_appdir() {
         fi
     done
 
+    # QtWebEngineProcess — Chromium subprocess, required for web views
+    if [ ! -f "$APPDIR/usr/libexec/QtWebEngineProcess" ]; then
+        err "Missing QtWebEngineProcess (Chromium subprocess)"
+        ((errors++))
+    fi
+
     # QML modules
     for mod in QtWebEngine QtQuick; do
         if [ ! -d "$APPDIR/usr/qml/$mod" ]; then
@@ -385,8 +398,62 @@ verify_appdir() {
     done
 
     # Node.js runtime
-    if [ ! -x "$APPDIR/usr/share/rattin/node/bin/node" ]; then
+    local node_bin="$APPDIR/usr/share/rattin/node/bin/node"
+    if [ ! -x "$node_bin" ]; then
         err "Missing Node.js runtime"
+        ((errors++))
+    fi
+
+    # Server bundle — must exist, be non-trivial, and parse without errors
+    local server_js="$APPDIR/usr/share/rattin/app/server.js"
+    if [ ! -f "$server_js" ]; then
+        err "Missing server.js bundle"
+        ((errors++))
+    else
+        local server_size
+        server_size="$(stat -c%s "$server_js")"
+        if [ "$server_size" -lt 10000 ]; then
+            err "server.js bundle suspiciously small (${server_size} bytes) — esbuild likely failed"
+            ((errors++))
+        fi
+        if [ -x "$node_bin" ]; then
+            if ! "$node_bin" --check "$server_js" 2>/dev/null; then
+                err "server.js bundle has syntax errors"
+                ((errors++))
+            fi
+        fi
+    fi
+
+    # Frontend assets — index.html plus at least one JS and CSS file
+    local public_dir="$APPDIR/usr/share/rattin/app/public"
+    if [ ! -f "$public_dir/index.html" ]; then
+        err "Missing frontend: public/index.html"
+        ((errors++))
+    fi
+    if ! ls "$public_dir"/assets/*.js >/dev/null 2>&1; then
+        err "Missing frontend JS assets in public/assets/"
+        ((errors++))
+    fi
+    if ! ls "$public_dir"/assets/*.css >/dev/null 2>&1; then
+        err "Missing frontend CSS assets in public/assets/"
+        ((errors++))
+    fi
+
+    # .env.example — required for first-run config creation
+    if [ ! -f "$APPDIR/usr/share/rattin/app/.env.example" ]; then
+        err "Missing .env.example"
+        ((errors++))
+    fi
+
+    # AppRun — entry point must be present and executable
+    if [ ! -x "$APPDIR/AppRun" ]; then
+        err "Missing or non-executable AppRun"
+        ((errors++))
+    fi
+
+    # node_modules — native addons directory must exist
+    if [ ! -d "$APPDIR/usr/share/rattin/app/node_modules" ]; then
+        err "Missing node_modules (npm ci --omit=dev likely failed)"
         ((errors++))
     fi
 

--- a/install/build-windows.ps1
+++ b/install/build-windows.ps1
@@ -76,6 +76,19 @@ if (Test-Path $NodeExe) {
     $nodeZip = Join-Path $ToolsDir "node.zip"
     $nodeUrl = "https://nodejs.org/dist/v$NodeVersion/node-v$NodeVersion-win-$Arch.zip"
     Invoke-WebRequest -Uri $nodeUrl -OutFile $nodeZip
+    # SHA256 verification
+    Log "Verifying Node.js checksum"
+    $shaUrl = "https://nodejs.org/dist/v$NodeVersion/SHASUMS256.txt"
+    $shaFile = Join-Path $ToolsDir "node-shasums.txt"
+    Invoke-WebRequest -Uri $shaUrl -OutFile $shaFile
+    $expected = (Get-Content $shaFile | Select-String "node-v$NodeVersion-win-$Arch.zip").ToString().Split(" ")[0]
+    $actual = (Get-FileHash $nodeZip -Algorithm SHA256).Hash.ToLower()
+    Remove-Item $shaFile
+    if ($expected -ne $actual) {
+        Remove-Item $nodeZip
+        Die "Node.js checksum mismatch! Expected: $expected Got: $actual"
+    }
+    Log "Node.js checksum verified"
     Expand-Archive $nodeZip -DestinationPath $ToolsDir -Force
     Rename-Item (Join-Path $ToolsDir "node-v$NodeVersion-win-$Arch") $NodeDir
     Remove-Item $nodeZip
@@ -223,7 +236,104 @@ Push-Location $AppDir
 Pop-Location
 
 # ---------------------------------------------------------------------------
-# Step 5: Create portable ZIP
+# Step 5: Verify distribution
+# ---------------------------------------------------------------------------
+function Verify-Distribution {
+    Log "Verifying distribution contents..."
+    $errors = 0
+
+    # Core binaries
+    foreach ($bin in @("rattin-shell.exe", "rattin-runtime.exe", "libmpv-2.dll")) {
+        if (-not (Test-Path (Join-Path $DistDir $bin))) {
+            Write-Host "[ERROR] Missing binary: $bin" -ForegroundColor Red
+            $errors++
+        }
+    }
+
+    # VC++ runtime DLLs
+    foreach ($dll in @("vcruntime140.dll", "msvcp140.dll")) {
+        if (-not (Test-Path (Join-Path $DistDir $dll))) {
+            Write-Host "[ERROR] Missing VC++ runtime: $dll" -ForegroundColor Red
+            $errors++
+        }
+    }
+
+    # Qt DLLs (windeployqt should have placed these)
+    foreach ($qt in @("Qt6Core.dll", "Qt6Gui.dll", "Qt6Quick.dll",
+                      "Qt6WebEngineCore.dll", "Qt6Network.dll", "Qt6WebChannel.dll")) {
+        if (-not (Test-Path (Join-Path $DistDir $qt))) {
+            Write-Host "[ERROR] Missing Qt DLL: $qt" -ForegroundColor Red
+            $errors++
+        }
+    }
+
+    # QtWebEngineProcess — Chromium subprocess
+    $webEngineProc = Join-Path $DistDir "QtWebEngineProcess.exe"
+    if (-not (Test-Path $webEngineProc)) {
+        Write-Host "[ERROR] Missing QtWebEngineProcess.exe (Chromium subprocess)" -ForegroundColor Red
+        $errors++
+    }
+
+    # Server bundle — must exist and be non-trivial
+    $serverJs = Join-Path $AppDir "server.js"
+    if (-not (Test-Path $serverJs)) {
+        Write-Host "[ERROR] Missing server.js bundle" -ForegroundColor Red
+        $errors++
+    } else {
+        $serverSize = (Get-Item $serverJs).Length
+        if ($serverSize -lt 10000) {
+            Write-Host "[ERROR] server.js suspiciously small ($serverSize bytes) — esbuild likely failed" -ForegroundColor Red
+            $errors++
+        }
+        # Syntax check with bundled node
+        $runtimeExe = Join-Path $DistDir "rattin-runtime.exe"
+        if (Test-Path $runtimeExe) {
+            $checkResult = & $runtimeExe --check $serverJs 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "[ERROR] server.js has syntax errors: $checkResult" -ForegroundColor Red
+                $errors++
+            }
+        }
+    }
+
+    # Frontend assets
+    $publicDir = Join-Path $AppDir "public"
+    if (-not (Test-Path (Join-Path $publicDir "index.html"))) {
+        Write-Host "[ERROR] Missing frontend: public/index.html" -ForegroundColor Red
+        $errors++
+    }
+    if (-not (Get-ChildItem (Join-Path $publicDir "assets") -Filter "*.js" -ErrorAction SilentlyContinue)) {
+        Write-Host "[ERROR] Missing frontend JS assets in public/assets/" -ForegroundColor Red
+        $errors++
+    }
+    if (-not (Get-ChildItem (Join-Path $publicDir "assets") -Filter "*.css" -ErrorAction SilentlyContinue)) {
+        Write-Host "[ERROR] Missing frontend CSS assets in public/assets/" -ForegroundColor Red
+        $errors++
+    }
+
+    # node_modules
+    if (-not (Test-Path (Join-Path $AppDir "node_modules"))) {
+        Write-Host "[ERROR] Missing node_modules (npm ci --omit=dev likely failed)" -ForegroundColor Red
+        $errors++
+    }
+
+    # Icon
+    if (-not (Test-Path (Join-Path $DistDir "rattin.ico"))) {
+        Write-Host "[ERROR] Missing rattin.ico" -ForegroundColor Red
+        $errors++
+    }
+
+    if ($errors -gt 0) {
+        Die "Distribution verification failed with $errors error(s) — refusing to package"
+    }
+
+    Log "Distribution verification passed"
+}
+
+Verify-Distribution
+
+# ---------------------------------------------------------------------------
+# Step 6: Create portable ZIP (was Step 5)
 # ---------------------------------------------------------------------------
 $zipOutput = Join-Path $RepoRoot "$AppName-$Arch-Portable.zip"
 Log "Creating portable ZIP: $zipOutput"
@@ -231,7 +341,7 @@ if (Test-Path $zipOutput) { Remove-Item $zipOutput }
 Compress-Archive -Path $DistDir -DestinationPath $zipOutput
 
 # ---------------------------------------------------------------------------
-# Step 6: NSIS installer (optional)
+# Step 7: NSIS installer (optional)
 # ---------------------------------------------------------------------------
 $makensis = Get-Command makensis -ErrorAction SilentlyContinue
 $nsiScript = Join-Path $RepoRoot "packaging/windows/rattin.nsi"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rattin",
-  "version": "2.7.5",
+  "version": "2.7.6-rc.1",
   "description": "",
   "type": "module",
   "main": "server.ts",


### PR DESCRIPTION
## Summary
- Build Linux AppImage on ubuntu-22.04 with Qt 6.7.3 from aqtinstall instead of ubuntu-24.04 system packages, lowering the GLIBC floor from 2.38 to 2.35
- Move filesystem operations in AppRun before LD_LIBRARY_PATH to prevent system commands from loading bundled libs
- Add comprehensive build verification for both Linux and Windows to prevent broken releases

## Verification
- **Linux `verify_appdir()`**: platform plugins, Qt libs, QML modules, QtWebEngineProcess, server.js syntax, frontend assets, GLIBC ceiling check (≤2.35)
- **Windows `Verify distribution`**: binaries, VC++ runtime, Qt DLLs, server.js syntax, frontend assets
- **Release `Verify artifact sizes`**: AppImage >100MB, Portable ZIP >100MB, Installer >50MB
- **SHA256SUMS.txt** published with every release
- **Validation gate**: typecheck + tests run before either build starts

## Compatibility
- Ubuntu 22.04+ (GLIBC 2.35) — **now works**
- Ubuntu 24.04+ (GLIBC 2.39) — still works
- Arch/CachyOS (GLIBC 2.41) — still works
- Debian 12+ (GLIBC 2.36) — still works

## Test plan
- [x] CI build passes (build-linux, build-windows, release)
- [x] AppImage launches on CachyOS (Arch)
- [ ] AppImage launches on Ubuntu 22.04 (user to confirm)