### PR TITLE
feat: add cast section to content details page

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,6 +4,7 @@ const img = (path: string | null, size = "w500"): string | null => (path ? `${TM
 export const backdrop = (path: string | null): string | null => img(path, "original");
 export const poster = (path: string | null, size = "w342"): string | null => img(path, size);
 export const still = (path: string | null): string | null => img(path, "w300");
+export const castProfile = (path: string | null): string | null => img(path, "w185");
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function get(url: string): Promise<any> {

--- a/src/pages/Detail.css
+++ b/src/pages/Detail.css
@@ -772,3 +772,116 @@
     gap: 28px;
   }
 }
+
+/* ── Cast Section ── */
+.cast-section {
+  margin-top: 48px;
+}
+
+.cast-header {
+  margin-bottom: 16px;
+}
+
+.cast-header h3 {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.cast-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 16px;
+}
+
+.cast-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+}
+
+.cast-photo {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.cast-photo-placeholder {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-dim) 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.cast-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cast-character {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+.cast-name {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.cast-show-more {
+  margin-top: 16px;
+  padding: 10px 16px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--accent-bright);
+  background: transparent;
+  border: 1px solid var(--accent-dim);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color var(--transition), border-color var(--transition);
+}
+
+.cast-show-more:hover {
+  color: var(--accent-bright);
+  border-color: var(--accent);
+}
+
+@media (max-width: 768px) {
+  .cast-section {
+    margin-top: 32px;
+  }
+
+  .cast-grid {
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+    gap: 12px;
+  }
+
+  .cast-photo,
+  .cast-photo-placeholder {
+    width: 50px;
+    height: 50px;
+  }
+
+  .cast-photo-placeholder {
+    font-size: 1.2rem;
+  }
+
+  .cast-character {
+    font-size: 0.8rem;
+  }
+
+  .cast-name {
+    font-size: 0.75rem;
+  }
+}

--- a/src/pages/Detail.css
+++ b/src/pages/Detail.css
@@ -853,7 +853,7 @@
 }
 
 .cast-show-more:hover {
-  color: var(--accent-bright);
+  color: var(--text-primary);
   border-color: var(--accent);
 }
 

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -45,6 +45,7 @@ export default function Detail() {
   useEffect(() => {
     setData(null);
     setPlayState(null);
+    setCastExpanded(false);
     const fetcher = type === "tv" ? fetchTV : fetchMovie;
     fetcher(id!).then(setData).catch(() => {});
   }, [id, type]);
@@ -264,7 +265,7 @@ export default function Detail() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const seasons = data.seasons?.filter((s: any) => s.season_number > 0);
   const genres = data.genres || [];
-  const cast = (data.credits?.cast || [])
+  const cast = [...(data.credits?.cast || [])]
     .sort((a: any, b: any) => (a.order || 0) - (b.order || 0))
     .slice(0, 20);
 
@@ -548,21 +549,21 @@ export default function Detail() {
               {(castExpanded ? cast : cast.slice(0, 6)).map((c: any) => (
                 <div key={c.id} className="cast-card">
                   {c.profile_path ? (
-                    <img className="cast-photo" src={castProfile(c.profile_path)!} alt={c.name} />
+                    <img className="cast-photo" src={castProfile(c.profile_path)!} alt={c.name} loading="lazy" />
                   ) : (
                     <div className="cast-photo-placeholder">
                       {c.name.charAt(0).toUpperCase()}
                     </div>
                   )}
                   <div className="cast-info">
-                    <span className="cast-character">{c.character}</span>
-                    <span className="cast-name">{c.name}</span>
+                    <span className="cast-character">{c.character || c.name}</span>
+                    <span className="cast-name">{c.character ? c.name : ""}</span>
                   </div>
                 </div>
               ))}
             </div>
             {cast.length > 6 && (
-              <button className="cast-show-more" onClick={() => setCastExpanded(!castExpanded)}>
+              <button className="cast-show-more" onClick={() => setCastExpanded(!castExpanded)} aria-expanded={castExpanded}>
                 {castExpanded ? "Show less" : `Show more (${cast.length - 6})`}
               </button>
             )}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
-import { fetchMovie, fetchTV, fetchSeason, fetchReviews, autoPlay, searchStreams, playTorrent, backdrop, poster, still, fetchResumePoint, fetchSeriesProgress, checkSaved, toggleSaved, reportWatchProgress } from "../lib/api";
+import { fetchMovie, fetchTV, fetchSeason, fetchReviews, autoPlay, searchStreams, playTorrent, backdrop, poster, still, fetchResumePoint, fetchSeriesProgress, checkSaved, toggleSaved, reportWatchProgress, castProfile } from "../lib/api";
 import { ratingColor, formatBytes } from "../lib/utils";
 import { useRemoteMode } from "../lib/PlayerContext";
 import { waitForBridge, mpvSetPoster, mpvSetTitle, mpvSetLoading, mpvSetLoadingStatus } from "../lib/native-bridge";
@@ -35,6 +35,7 @@ export default function Detail() {
   const [expandedReview, setExpandedReview] = useState<string | null>(null);
   const [showAllReddit, setShowAllReddit] = useState(false);
   const [showAllReviews, setShowAllReviews] = useState(false);
+  const [castExpanded, setCastExpanded] = useState(false);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [resumePoint, setResumePoint] = useState<any>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -263,6 +264,9 @@ export default function Detail() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const seasons = data.seasons?.filter((s: any) => s.season_number > 0);
   const genres = data.genres || [];
+  const cast = (data.credits?.cast || [])
+    .sort((a: any, b: any) => (a.order || 0) - (b.order || 0))
+    .slice(0, 20);
 
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -532,6 +536,36 @@ export default function Detail() {
                 })
               )}
             </div>
+          </div>
+        )}
+
+        {cast && cast.length > 0 && (
+          <div className="cast-section">
+            <div className="cast-header">
+              <h3>Cast</h3>
+            </div>
+            <div className="cast-grid">
+              {(castExpanded ? cast : cast.slice(0, 6)).map((c: any) => (
+                <div key={c.id} className="cast-card">
+                  {c.profile_path ? (
+                    <img className="cast-photo" src={castProfile(c.profile_path)!} alt={c.name} />
+                  ) : (
+                    <div className="cast-photo-placeholder">
+                      {c.name.charAt(0).toUpperCase()}
+                    </div>
+                  )}
+                  <div className="cast-info">
+                    <span className="cast-character">{c.character}</span>
+                    <span className="cast-name">{c.name}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+            {cast.length > 6 && (
+              <button className="cast-show-more" onClick={() => setCastExpanded(!castExpanded)}>
+                {castExpanded ? "Show less" : `Show more (${cast.length - 6})`}
+              </button>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
Add a collapsible Cast section to the content details page, positioned between the episode list and Reddit discussions.

## Changes
- **src/lib/api.ts**: Add `castProfile()` helper for TMDB w185 cast images
- **src/pages/Detail.tsx**: Add Cast section component with expand/collapse
- **src/pages/Detail.css**: Add responsive grid styles for cast cards

## Features
- Shows actor photo (60px circular), character name (bold), and actor name
- Displays 6 cast members initially, expandable to show up to 20
- Placeholder with first initial when no photo available
- Responsive grid layout (adapts to screen size)
- Uses existing TMDB credits data (no new API calls)

## Data Source
TMDB API `credits.cast` array with fields: `id`, `name`, `character`, `profile_path`, `order`

## Testing
- [ ] Cast section appears on movie detail pages
- [ ] Cast section appears on TV detail pages  
- [ ] Section shows ~6 cast members initially
- [ ] "Show more" expands to show all cast (up to 20)
- [ ] Actor photos load correctly from TMDB
- [ ] Placeholder shows when no photo available