### PR TITLE
fix: validate resume point against TMDB seasons data

### DIFF
--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -7,6 +7,14 @@ import { waitForBridge, mpvSetPoster, mpvSetTitle, mpvSetLoading, mpvSetLoadingS
 import SourcePicker from "../components/SourcePicker";
 import "./Detail.css";
 
+// Helper to check if resume point season exists in available seasons
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isValidResumePoint(resumePoint: any, seasons: any[]): boolean {
+  if (!resumePoint || resumePoint.season <= 0 || !seasons?.length) return false;
+  const maxSeason = Math.max(...seasons.map((s) => s.season_number), 0);
+  return resumePoint.season <= maxSeason;
+}
+
 export default function Detail() {
   const { id } = useParams();
   const location = useLocation();
@@ -65,9 +73,18 @@ export default function Detail() {
   function refreshResumePoint() {
     if (!id) return;
     fetchResumePoint(Number(id), type).then((r) => {
-      setResumePoint(r.resumePoint);
-      if (r.resumePoint?.season && type === "tv" && !sessionStorage.getItem(`season:${id}`)) {
-        setSelectedSeason(r.resumePoint.season);
+      let point = r.resumePoint;
+      // Validate resume point against available TMDB seasons for TV shows
+      if (point && type === "tv" && data?.seasons) {
+        const availableSeasons = data.seasons.filter((s: any) => s.season_number > 0);
+        const maxSeason = Math.max(...availableSeasons.map((s: any) => s.season_number), 0);
+        if (point.season > maxSeason) {
+          point = null; // Resume point refers to non-existent season
+        }
+      }
+      setResumePoint(point);
+      if (point?.season && type === "tv" && !sessionStorage.getItem(`season:${id}`)) {
+        setSelectedSeason(point.season);
       }
     }).catch(() => {});
   }
@@ -79,6 +96,16 @@ export default function Detail() {
     refreshResumePoint();
     checkSaved(type, Number(id)).then((r) => setIsSaved(r.saved)).catch(() => {});
   }, [id, type]);
+
+  // Re-validate resume point when data (seasons) loads
+  useEffect(() => {
+    if (type !== "tv" || !resumePoint || !data?.seasons) return;
+    const availableSeasons = data.seasons.filter((s: any) => s.season_number > 0);
+    const maxSeason = Math.max(...availableSeasons.map((s: any) => s.season_number), 0);
+    if (resumePoint.season > maxSeason) {
+      setResumePoint(null); // Clear invalid resume point
+    }
+  }, [data?.seasons, resumePoint, type]);
 
   // Fetch episode progress for TV
   useEffect(() => {
@@ -324,7 +351,7 @@ export default function Detail() {
               <button
                 className="detail-play-btn"
                 onClick={() => {
-                  if (resumePoint && type === "tv" && resumePoint.season > 0) {
+                  if (type === "tv" && isValidResumePoint(resumePoint, seasons)) {
                     handlePlay(resumePoint.season, resumePoint.episode);
                   } else if (type === "tv") {
                     handlePlay(1, 1);
@@ -341,9 +368,9 @@ export default function Detail() {
                     <svg viewBox="0 0 24 24" width="22" height="22" fill="currentColor">
                       <path d="M8 5v14l11-7z" />
                     </svg>
-                    {resumePoint && type === "tv" && resumePoint.season > 0
+                    {type === "tv" && isValidResumePoint(resumePoint, seasons)
                       ? `Resume S${resumePoint.season}E${resumePoint.episode}`
-                      : resumePoint && type === "movie" && resumePoint.position > 0
+                      : type === "movie" && resumePoint?.position > 0
                         ? "Resume"
                         : "Play"}
                   </>


### PR DESCRIPTION
## Problem
When a user has watched all episodes of a TV show up to the last episode of the last season, the resume button incorrectly shows "Resume S{N+1}E1" (suggesting the first episode of a non-existent next season).

## Root Cause
The backend's `getResumePoint()` function relies on stored `seasonCount` data which may be:
- `undefined` if never recorded
- Stale (from when the episode was originally watched)

When `seasonCount` is undefined, the logic assumes there's always a next season, returning `{season: N+1, episode: 1}`.

## Solution
Add frontend validation in `Detail.tsx` to check if the resume point's season actually exists in the current TMDB data before displaying it.

### Changes
- Add `isValidResumePoint()` helper function to validate resume point against available seasons
- Update `refreshResumePoint()` to validate after fetching from API
- Add `useEffect` to re-validate when TMDB data loads
- Update button onClick handler to use validation
- Update button text logic to show "Play" for invalid resume points

## Testing
- Build passes: ✅
- Existing tests: 310 pass (6 pre-existing failures unrelated to this change)

## Related
Bug report: Resume button shows non-existent season+1 episode 1 when all episodes watched
