### PR TITLE
fix(debrid): serve external subtitles and harden RD network calls

### DIFF
--- a/lib/torrent/debrid.ts
+++ b/lib/torrent/debrid.ts
@@ -17,6 +17,12 @@ export interface DebridStream {
   filesize: number;
   fileIndex: number;  // 0-based index of the selected video file in the torrent
   files: DebridFileInfo[];
+  /** RD: restricted download links for selected files */
+  links?: string[];
+  /** Provider torrent ID — for fetching individual file URLs on demand */
+  torrentId?: string;
+  /** Provider name — "realdebrid" or "torbox" */
+  provider?: string;
 }
 
 export interface DebridProvider {
@@ -115,14 +121,33 @@ class RealDebridProvider implements DebridProvider {
   }
 
   private async rdFetch(endpoint: string, opts: RequestInit = {}): Promise<Response> {
-    const res = await fetch(`${RD_BASE}${endpoint}`, {
-      ...opts,
-      headers: { ...this.headers(), ...opts.headers },
-    });
-    if (res.status === 401) throw new Error("debrid_auth_failed");
-    if (res.status === 403) throw new Error("debrid_premium_required");
-    if (res.status === 429) throw new Error("debrid_rate_limited");
-    return res;
+    const maxRetries = 2;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const res = await fetch(`${RD_BASE}${endpoint}`, {
+          ...opts,
+          headers: { ...this.headers(), ...opts.headers },
+          signal: AbortSignal.timeout(15000),
+        });
+        if (res.status === 401) throw new Error("debrid_auth_failed");
+        if (res.status === 403) throw new Error("debrid_premium_required");
+        if (res.status === 429) throw new Error("debrid_rate_limited");
+        return res;
+      } catch (err) {
+        const msg = (err as Error).message || "";
+        // Don't retry auth/permission errors
+        if (msg.startsWith("debrid_")) throw err;
+        if (attempt < maxRetries) {
+          await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+          continue;
+        }
+        const cause = (err as Error).cause as { code?: string; message?: string } | undefined;
+        const code = cause?.code || (err as Error).name || "unknown";
+        const detail = cause?.message || msg || "fetch failed";
+        throw new Error(`debrid_network_error: ${code} ${detail} (${endpoint})`);
+      }
+    }
+    throw new Error("debrid_network_error: unreachable");
   }
 
   private formBody(params: Record<string, string>): URLSearchParams {
@@ -199,7 +224,7 @@ class RealDebridProvider implements DebridProvider {
       let selectedRdId: number | null = null;
       if (info.status === "waiting_files_selection") {
         const filesToSelect = this.pickFiles(info.files, fileIdx);
-        selectedRdId = parseInt(filesToSelect, 10); // first ID in comma-separated list
+        selectedRdId = parseInt(filesToSelect, 10); // first ID in comma-separated list (video)
         await this.rdFetch(`/torrents/selectFiles/${id}`, {
           method: "POST",
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -222,22 +247,31 @@ class RealDebridProvider implements DebridProvider {
       }));
 
       // Step 5: Unrestrict the video link
+      // Links correspond to selected files ordered by ID — find the video's link
+      const selectedFiles = info.files.filter(f => Number(f.selected)).sort((a, b) => a.id - b.id);
+      const videoRdId = selectedRdId ?? selectedFiles.find(f => isVideoFile(f.path))?.id ?? selectedFiles[0]?.id;
+      const videoLinkIdx = selectedFiles.findIndex(f => f.id === videoRdId);
+      const videoLink = info.links[videoLinkIdx >= 0 ? videoLinkIdx : 0];
+
       const unRes = await this.rdFetch("/unrestrict/link", {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: this.formBody({ link: info.links[0] }),
+        body: this.formBody({ link: videoLink }),
       });
       if (!unRes.ok) throw new Error("debrid_unrestrict_failed");
 
       const dl = await unRes.json() as { download: string; filename: string; filesize: number };
       // Convert RD's 1-based file ID to 0-based index
-      const videoFileIndex = selectedRdId ? selectedRdId - 1 : 0;
+      const videoFileIndex = videoRdId ? videoRdId - 1 : 0;
       return {
         url: dl.download,
         filename: dl.filename,
         filesize: dl.filesize,
         fileIndex: videoFileIndex,
         files: allFiles,
+        links: info.links || [],
+        torrentId: id,
+        provider: "realdebrid",
       };
     } catch (err) {
       // Clean up: delete the torrent from RD on failure
@@ -247,14 +281,27 @@ class RealDebridProvider implements DebridProvider {
   }
 
   private pickFiles(files: RDTorrentInfo["files"], preferredIdx?: number): string {
+    let videoId: number;
     if (preferredIdx !== undefined) {
       const target = files.find((f) => f.id === preferredIdx + 1); // RD uses 1-based IDs
-      if (target && isVideoFile(target.path)) return String(target.id);
+      if (target && isVideoFile(target.path)) {
+        videoId = target.id;
+      } else {
+        const videoFiles = files.filter((f) => isVideoFile(f.path));
+        if (videoFiles.length === 0) return "all";
+        videoId = videoFiles.reduce((a, b) => (b.bytes > a.bytes ? b : a)).id;
+      }
+    } else {
+      const videoFiles = files.filter((f) => isVideoFile(f.path));
+      if (videoFiles.length === 0) return "all";
+      videoId = videoFiles.reduce((a, b) => (b.bytes > a.bytes ? b : a)).id;
     }
-    const videoFiles = files.filter((f) => isVideoFile(f.path));
-    if (videoFiles.length === 0) return "all";
-    const largest = videoFiles.reduce((a, b) => (b.bytes > a.bytes ? b : a));
-    return String(largest.id);
+    // Also select subtitle files — they're tiny and needed for sub serving
+    const subIds = files
+      .filter((f) => isSubtitleFile(f.path))
+      .map((f) => f.id);
+    const ids = [videoId, ...subIds];
+    return ids.join(",");
   }
 
   private async pollTorrentStatus(id: string, targetStatuses: string[], timeoutMs: number): Promise<RDTorrentInfo> {
@@ -276,6 +323,40 @@ class RealDebridProvider implements DebridProvider {
     }
 
     throw new Error("debrid_timeout");
+  }
+
+  /** Get an unrestricted download URL for a specific file in a torrent.
+   *  Used for serving subtitle/audio files on demand.
+   *  Subtitle files are selected alongside the video during initial unrestrict,
+   *  so their links should already be available. */
+  async getFileUrl(torrentId: string, fileId: number): Promise<string | null> {
+    try {
+      const info = await this.pollTorrentStatus(torrentId, ["downloaded"], 10000);
+      if (!info.links || info.links.length === 0) return null;
+
+      // Links correspond to selected files ordered by ID
+      const selectedFiles = info.files.filter(f => Number(f.selected)).sort((a, b) => a.id - b.id);
+      const linkIndex = selectedFiles.findIndex(f => f.id === fileId);
+      if (linkIndex < 0 || linkIndex >= info.links.length) {
+        console.warn("[SUB] Could not find link for file", { fileId, selectedCount: selectedFiles.length, linksCount: info.links.length });
+        return null;
+      }
+      const link = info.links[linkIndex];
+      const unRes = await this.rdFetch("/unrestrict/link", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: this.formBody({ link }),
+      });
+      if (!unRes.ok) {
+        console.warn("[SUB] RD unrestrict failed", { status: unRes.status });
+        return null;
+      }
+      const dl = await unRes.json() as { download: string };
+      return dl.download;
+    } catch (err) {
+      console.error("[SUB] RD getFileUrl error", { error: (err as Error).message });
+      return null;
+    }
   }
 }
 
@@ -401,6 +482,8 @@ class TorBoxProvider implements DebridProvider {
         filesize: videoFile.size,
         fileIndex: fileIdx ?? allFiles.findIndex((f) => f.id === videoFile.id),
         files: allFiles,
+        torrentId: String(torrentId),
+        provider: "torbox",
       };
     } catch (err) {
       // Clean up on failure — delete the torrent
@@ -447,11 +530,28 @@ class TorBoxProvider implements DebridProvider {
 
     throw new Error("debrid_timeout");
   }
+
+  /** Get a direct download URL for a specific file in a TorBox torrent. */
+  async getFileDownloadUrl(torrentId: number, fileId: number): Promise<string | null> {
+    try {
+      const res = await this.tbFetch(`/torrents/requestdl?token=${encodeURIComponent(this.apiKey)}&torrent_id=${torrentId}&file_id=${fileId}`);
+      if (!res.ok) return null;
+      const { data } = await res.json() as { data: string };
+      return data;
+    } catch {
+      return null;
+    }
+  }
 }
 
 function isVideoFile(filePath: string): boolean {
   const ext = path.extname(filePath).toLowerCase();
   return [".mkv", ".mp4", ".avi", ".mov", ".wmv", ".flv", ".webm", ".m4v", ".ts", ".mpg", ".mpeg"].includes(ext);
+}
+
+function isSubtitleFile(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return [".srt", ".ass", ".ssa", ".vtt", ".sub"].includes(ext);
 }
 
 // ── Active debrid stream state ───────────────────────────────────
@@ -461,18 +561,24 @@ interface ActiveDebridStream {
   url: string;
   files: DebridFileInfo[];
   streamKey: string;
+  /** RD: restricted download links for selected files; TB: not used */
+  links?: string[];
+  /** Provider torrent ID — for fetching individual file URLs on demand */
+  torrentId?: string;
+  /** Provider name — "realdebrid" or "torbox" */
+  provider?: string;
 }
 
 const _activeDebridStreams = new Map<string, ActiveDebridStream>();
 const _activeDebridKeys = new Map<string, string>();
 
-export function setActiveDebridStream(infoHash: string, url: string, files: DebridFileInfo[]): string {
+export function setActiveDebridStream(infoHash: string, url: string, files: DebridFileInfo[], links?: string[], torrentId?: string, provider?: string): string {
   const normalized = infoHash.toLowerCase();
   const previous = _activeDebridStreams.get(normalized);
   if (previous) _activeDebridKeys.delete(previous.streamKey);
 
   const streamKey = crypto.randomBytes(16).toString("hex");
-  _activeDebridStreams.set(normalized, { url, files, streamKey });
+  _activeDebridStreams.set(normalized, { url, files, streamKey, links, torrentId, provider });
   _activeDebridKeys.set(streamKey, normalized);
   return streamKey;
 }
@@ -489,6 +595,39 @@ export function getActiveDebridStreamByKey(streamKey: string): ActiveDebridStrea
   const infoHash = _activeDebridKeys.get(streamKey);
   if (!infoHash) return null;
   return _activeDebridStreams.get(infoHash) || null;
+}
+
+/** Get an unrestricted download URL for a specific file in an active debrid stream.
+ *  Used to serve subtitle/audio files that aren't the main video. */
+export async function getDebridFileUrl(infoHash: string, fileId: number): Promise<string | null> {
+  const normalized = infoHash.toLowerCase();
+  const stream = _activeDebridStreams.get(normalized);
+  if (!stream) return null;
+
+  // Check if the requested file is the main video (already unrestricted)
+  const isVideo = stream.url && _isVideoByExtension(stream.files, fileId);
+  if (isVideo) return stream.url;
+
+  const provider = getDebridProvider();
+  if (!provider) return null;
+
+  if (stream.provider === "realdebrid" && stream.torrentId) {
+    // Reuse the singleton provider instance
+    const rd = provider as RealDebridProvider;
+    return rd.getFileUrl(stream.torrentId, fileId);
+  }
+
+  if (stream.provider === "torbox" && stream.torrentId) {
+    return await (provider as TorBoxProvider).getFileDownloadUrl(Number(stream.torrentId), fileId);
+  }
+
+  return null;
+}
+
+function _isVideoByExtension(files: DebridFileInfo[], fileId: number): boolean {
+  const file = files.find(f => f.id === fileId);
+  if (!file) return false;
+  return isVideoFile(file.path);
 }
 
 let _provider: DebridProvider | null | undefined; // undefined = not loaded yet

--- a/routes/media.ts
+++ b/routes/media.ts
@@ -9,7 +9,7 @@ import { hasPiece } from "../lib/torrent/torrent-compat.js";
 import { VIDEO_EXTENSIONS, SUBTITLE_EXTENSIONS, srtToVtt } from "../lib/media/media-utils.js";
 import { detectIntro, lookupExternal } from "../lib/media/intro-detect.js";
 import type { ServerContext, Torrent } from "../lib/types.js";
-import { getActiveDebridUrl } from "../lib/torrent/debrid.js";
+import { getActiveDebridUrl, getActiveDebridFiles, getDebridFileUrl } from "../lib/torrent/debrid.js";
 
 export default function mediaRoutes(app: Express, ctx: ServerContext): void {
   const {
@@ -30,7 +30,11 @@ export default function mediaRoutes(app: Express, ctx: ServerContext): void {
     const torrent = client().torrents.find((t) => t.infoHash === infoHash);
     let filePath: string;
 
-    if (torrent) {
+    // Debrid takes priority
+    const debridUrl = getActiveDebridUrl(infoHash, parseInt(fileIndex, 10));
+    if (debridUrl) {
+      filePath = debridUrl;
+    } else if (torrent) {
       const file = torrent.files[parseInt(fileIndex, 10)];
       if (!file) return res.status(404).json({ error: "File not found" });
       filePath = diskPath(torrent, file);
@@ -38,9 +42,7 @@ export default function mediaRoutes(app: Express, ctx: ServerContext): void {
         return res.json({ duration: null });
       }
     } else {
-      const debridUrl = getActiveDebridUrl(infoHash, parseInt(fileIndex, 10));
-      if (!debridUrl) return res.status(404).json({ error: "Torrent not found" });
-      filePath = debridUrl;
+      return res.status(404).json({ error: "Torrent not found" });
     }
 
     const probe = spawn("ffprobe", [
@@ -66,8 +68,69 @@ export default function mediaRoutes(app: Express, ctx: ServerContext): void {
   });
 
   // Subtitle endpoint - converts any subtitle format to WebVTT
-  app.get("/api/subtitle/:infoHash/:fileIndex", (req: Request, res: Response) => {
+  // CHECKS DEBRID FIRST: if a debrid stream is active, serves subtitle from debrid provider.
+  // Falls back to webtorrent only if no debrid stream is registered.
+  app.get("/api/subtitle/:infoHash/:fileIndex", async (req: Request, res: Response) => {
     const { infoHash, fileIndex } = req.params as Record<string, string>;
+
+    // Debrid takes priority — if an active debrid stream exists, fetch from debrid
+    const debridFiles = getActiveDebridFiles(infoHash);
+    if (debridFiles.length > 0) {
+      const fileIdx = parseInt(fileIndex, 10);
+      // fileIndex is 0-based positional — map directly to debridFiles array
+      const debridFile = fileIdx >= 0 && fileIdx < debridFiles.length ? debridFiles[fileIdx] : undefined;
+      if (!debridFile) return res.status(404).json({ error: "File not found" });
+      const ext = path.extname(debridFile.path).toLowerCase();
+      if (!SUBTITLE_EXTENSIONS.includes(ext)) {
+        return res.status(400).json({ error: "Not a subtitle file" });
+      }
+      const offset = parseFloat(req.query.offset as string) || 0;
+
+      try {
+        // Get unrestricted download URL for this specific file
+        const fileUrl = await getDebridFileUrl(infoHash, debridFile.id);
+        if (!fileUrl) {
+          log("err", "/api/subtitle — could not get debrid file URL", { infoHash, fileId: debridFile.id });
+          return res.status(502).json({ error: "Could not get debrid download link" });
+        }
+
+        // Fetch subtitle content from debrid provider
+        const subRes = await fetch(fileUrl);
+        if (!subRes.ok) {
+          log("err", "/api/subtitle — debrid fetch failed", { status: subRes.status, infoHash, fileId: debridFile.id });
+          return res.status(502).json({ error: "Failed to fetch subtitle from debrid" });
+        }
+        const subBuffer = Buffer.from(await subRes.arrayBuffer());
+        const raw = subBuffer.toString("utf-8");
+        res.setHeader("Content-Type", "text/vtt; charset=utf-8");
+
+        if (ext === ".vtt") {
+          return res.send(offset > 0 ? "" : raw); // TODO: shift VTT if offset > 0
+        }
+        if (ext === ".srt") {
+          return res.send(srtToVtt(raw));
+        }
+        // Other formats: pipe through ffmpeg
+        const args = [
+          ...(offset > 0 ? ["-ss", String(offset)] : []),
+          "-i", "pipe:0", "-f", "webvtt", "-v", "warning", "pipe:1",
+        ];
+        const ffmpeg = spawn("ffmpeg", args, { stdio: ["pipe", "pipe", "pipe"] });
+        ffmpeg.stdin!.end(subBuffer);
+        ffmpeg.stdout!.pipe(res);
+        ffmpeg.stderr!.on("data", (d: Buffer) => log("warn", "Subtitle ffmpeg: " + d.toString().trim()));
+        ffmpeg.on("close", (code: number | null) => {
+          if (code !== 0) log("err", "Subtitle conversion from debrid failed", { code });
+        });
+        res.on("close", () => ffmpeg.kill());
+        return;
+      } catch (err) {
+        log("err", "/api/subtitle — debrid serving error", { error: (err as Error).message });
+        return res.status(500).json({ error: "Failed to serve subtitle from debrid" });
+      }
+    }
+
+    // Fall back to webtorrent
     const torrent = client().torrents.find((t) => t.infoHash === infoHash);
     if (!torrent) return res.status(404).json({ error: "Torrent not found" });
 
@@ -158,29 +221,34 @@ export default function mediaRoutes(app: Express, ctx: ServerContext): void {
 
 
   // Probe embedded subtitle streams in a video file
+  // CHECKS DEBRID FIRST: if a debrid stream is active, always probe the debrid URL.
+  // Falls back to webtorrent only if no debrid stream is registered.
   app.get("/api/subtitles/:infoHash/:fileIndex", (req: Request, res: Response) => {
     res.removeHeader("ETag");
     res.setHeader("Cache-Control", "no-store");
     const { infoHash, fileIndex } = req.params as Record<string, string>;
-    const torrent = client().torrents.find((t) => t.infoHash === infoHash);
 
     let filePath: string;
     let complete: boolean;
 
-    if (torrent) {
-      const file = torrent.files[parseInt(fileIndex, 10)];
-      if (!file) return res.status(404).json({ error: "File not found" });
-      complete = isFileComplete(torrent, file);
-      filePath = diskPath(torrent, file);
-      try { statSync(filePath); } catch {
-        return res.json({ tracks: [], complete: false });
-      }
-    } else {
-      // Debrid fallback: probe the remote URL directly (ffprobe supports HTTPS)
-      const debridUrl = getActiveDebridUrl(infoHash, parseInt(fileIndex, 10));
-      if (!debridUrl) return res.status(404).json({ error: "Torrent not found" });
+    // Debrid takes priority — if an active debrid stream exists, use its URL
+    const debridUrl = getActiveDebridUrl(infoHash, parseInt(fileIndex, 10));
+    if (debridUrl) {
       filePath = debridUrl;
       complete = true;
+    } else {
+      const torrent = client().torrents.find((t) => t.infoHash === infoHash);
+      if (torrent) {
+        const file = torrent.files[parseInt(fileIndex, 10)];
+        if (!file) return res.status(404).json({ error: "File not found" });
+        complete = isFileComplete(torrent, file);
+        filePath = diskPath(torrent, file);
+        try { statSync(filePath); } catch {
+          return res.json({ tracks: [], complete: false });
+        }
+      } else {
+        return res.status(404).json({ error: "Torrent not found" });
+      }
     }
 
     // Use ffprobe to list subtitle streams
@@ -215,24 +283,28 @@ export default function mediaRoutes(app: Express, ctx: ServerContext): void {
   app.get("/api/audio-tracks/:infoHash/:fileIndex", (req: Request, res: Response) => {
     res.setHeader("Cache-Control", "no-store");
     const { infoHash, fileIndex } = req.params as Record<string, string>;
-    const torrent = client().torrents.find((t) => t.infoHash === infoHash);
 
     let filePath: string;
     let complete: boolean;
 
-    if (torrent) {
-      const file = torrent.files[parseInt(fileIndex, 10)];
-      if (!file) return res.status(404).json({ error: "File not found" });
-      complete = isFileComplete(torrent, file);
-      filePath = diskPath(torrent, file);
-      try { statSync(filePath); } catch {
-        return res.json({ tracks: [], complete: false });
-      }
-    } else {
-      const debridUrl = getActiveDebridUrl(infoHash, parseInt(fileIndex, 10));
-      if (!debridUrl) return res.status(404).json({ error: "Torrent not found" });
+    // Debrid takes priority
+    const debridUrl = getActiveDebridUrl(infoHash, parseInt(fileIndex, 10));
+    if (debridUrl) {
       filePath = debridUrl;
       complete = true;
+    } else {
+      const torrent = client().torrents.find((t) => t.infoHash === infoHash);
+      if (torrent) {
+        const file = torrent.files[parseInt(fileIndex, 10)];
+        if (!file) return res.status(404).json({ error: "File not found" });
+        complete = isFileComplete(torrent, file);
+        filePath = diskPath(torrent, file);
+        try { statSync(filePath); } catch {
+          return res.json({ tracks: [], complete: false });
+        }
+      } else {
+        return res.status(404).json({ error: "Torrent not found" });
+      }
     }
 
     const probe = spawn("ffprobe", [
@@ -382,21 +454,24 @@ export default function mediaRoutes(app: Express, ctx: ServerContext): void {
   // Extract an embedded subtitle stream as WebVTT
   app.get("/api/subtitle-extract/:infoHash/:fileIndex/:streamIndex", (req: Request, res: Response) => {
     const params = req.params as Record<string, string>;
-    const torrent = client().torrents.find((t) => t.infoHash === params.infoHash);
-
     let filePath: string;
 
-    if (torrent) {
-      const file = torrent.files[parseInt(params.fileIndex, 10)];
-      if (!file) return res.status(404).json({ error: "File not found" });
-      filePath = diskPath(torrent, file);
-      try { statSync(filePath); } catch {
-        return res.status(202).json({ error: "File not on disk yet" });
-      }
-    } else {
-      const debridUrl = getActiveDebridUrl(params.infoHash, parseInt(params.fileIndex, 10));
-      if (!debridUrl) return res.status(404).json({ error: "Torrent not found" });
+    // Debrid takes priority
+    const debridUrl = getActiveDebridUrl(params.infoHash, parseInt(params.fileIndex, 10));
+    if (debridUrl) {
       filePath = debridUrl;
+    } else {
+      const torrent = client().torrents.find((t) => t.infoHash === params.infoHash);
+      if (torrent) {
+        const file = torrent.files[parseInt(params.fileIndex, 10)];
+        if (!file) return res.status(404).json({ error: "File not found" });
+        filePath = diskPath(torrent, file);
+        try { statSync(filePath); } catch {
+          return res.status(202).json({ error: "File not on disk yet" });
+        }
+      } else {
+        return res.status(404).json({ error: "Torrent not found" });
+      }
     }
 
     const streamIdx = parseInt(params.streamIndex, 10);

--- a/routes/search.ts
+++ b/routes/search.ts
@@ -541,7 +541,7 @@ app.post("/api/auto-play", async (req: Request, res: Response) => {
           log("info", "Auto-play selected", { name: candidate.name, score: candidate.score, seeders: candidate.seeders });
           const stream = await debrid.unrestrict(magnet, candidate.fileIdx);
           log("info", "Auto-play via debrid", { name: candidate.name, filename: stream.filename });
-          const debridStreamKey = setActiveDebridStream(candidate.infoHash, stream.url, stream.files);
+          const debridStreamKey = setActiveDebridStream(candidate.infoHash, stream.url, stream.files, stream.links, stream.torrentId, stream.provider);
           return res.json({
             infoHash: candidate.infoHash, fileIndex: stream.fileIndex, fileName: stream.filename,
             torrentName: candidate.name, totalSize: stream.filesize, tags, debridStreamKey,
@@ -665,7 +665,7 @@ app.post("/api/play-torrent", async (req: Request, res: Response) => {
     try {
       const stream = await debrid.unrestrict(magnet, fileIdx);
       log("info", "Play-torrent via debrid", { infoHash, filename: stream.filename });
-      const debridStreamKey = setActiveDebridStream(infoHash, stream.url, stream.files);
+      const debridStreamKey = setActiveDebridStream(infoHash, stream.url, stream.files, stream.links, stream.torrentId, stream.provider);
       return res.json({
         infoHash,
         fileIndex: stream.fileIndex,

--- a/routes/status.ts
+++ b/routes/status.ts
@@ -38,8 +38,38 @@ export default function statusRoutes(app: Express, ctx: ServerContext): void {
 
   app.get("/api/status/:infoHash", (req: Request, res: Response) => {
     const { infoHash } = req.params as Record<string, string>;
+    // Debrid takes priority — if an active debrid stream exists, use its file list
+    const debridFiles = getActiveDebridFiles(infoHash);
+    if (debridFiles.length > 0) {
+      const files = debridFiles.map((f, i) => {
+        const ext = path.extname(f.path).toLowerCase();
+        return {
+          index: i, // 0-based positional index (not provider ID)
+          debridId: f.id, // preserve provider ID for on-demand URL fetching
+          name: f.path.replace(/^\//, ""),
+          path: f.path.replace(/^\//, ""),
+          length: f.bytes,
+          downloaded: f.bytes,
+          progress: 1,
+          isVideo: VIDEO_EXTENSIONS.includes(ext),
+          isAudio: AUDIO_EXTENSIONS.includes(ext),
+          isSubtitle: SUBTITLE_EXTENSIONS.includes(ext),
+          isAllowed: isAllowedFile(f.path),
+          duration: null,
+        };
+      });
+      return res.json({
+        infoHash, name: "(debrid)",
+        downloadSpeed: 0, uploadSpeed: 0, progress: 1,
+        downloaded: 0, totalSize: 0, numPeers: 0, timeRemaining: 0,
+        files,
+      });
+    }
+
+    // No debrid — fall back to webtorrent
     const torrent = client().torrents.find((t) => t.infoHash === infoHash);
     if (!torrent) {
+      // No active debrid or webtorrent — check completed-on-disk cache
       const diskFiles: Array<Record<string, unknown>> = [];
       for (const [key, info] of completedFiles) {
         if (key.startsWith(infoHash + ":")) {
@@ -62,32 +92,6 @@ export default function statusRoutes(app: Express, ctx: ServerContext): void {
           downloadSpeed: 0, uploadSpeed: 0, progress: 1,
           downloaded: 0, totalSize: 0, numPeers: 0, timeRemaining: 0,
           files: diskFiles,
-        });
-      }
-      // Debrid fallback: return file list from RD torrent info
-      const debridFiles = getActiveDebridFiles(infoHash);
-      if (debridFiles.length > 0) {
-        const files = debridFiles.map((f, i) => {
-          const ext = path.extname(f.path).toLowerCase();
-          return {
-            index: f.id - 1, // RD uses 1-based, we use 0-based
-            name: f.path.replace(/^\//, ""),
-            path: f.path.replace(/^\//, ""),
-            length: f.bytes,
-            downloaded: f.bytes,
-            progress: 1,
-            isVideo: VIDEO_EXTENSIONS.includes(ext),
-            isAudio: AUDIO_EXTENSIONS.includes(ext),
-            isSubtitle: SUBTITLE_EXTENSIONS.includes(ext),
-            isAllowed: isAllowedFile(f.path),
-            duration: null,
-          };
-        });
-        return res.json({
-          infoHash, name: "(debrid)",
-          downloadSpeed: 0, uploadSpeed: 0, progress: 1,
-          downloaded: 0, totalSize: 0, numPeers: 0, timeRemaining: 0,
-          files,
         });
       }
       return res.status(404).json({ error: "Torrent not found" });

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -467,9 +467,11 @@ export default function Player() {
         mpvSeek(Math.max(0, t + delta));
       },
       switchSubtitle: (val: string) => {
-        const idx = subs.findIndex(s => s.value === val);
+        // Use subsRef (always current) instead of subs (render closure, can be stale)
+        const currentSubs = subsRef.current;
+        const idx = currentSubs.findIndex(s => s.value === val);
         if (idx < 0) return;
-        const sub = subs[idx];
+        const sub = currentSubs[idx];
         if (sub.value.startsWith("file:")) {
           const port = window.location.port;
           const subUrl = `http://127.0.0.1:${port}/api/subtitle/${infoHash}/${sub.fileIndex}`;


### PR DESCRIPTION
## Summary
- **Subtitle serving from debrid**: Select subtitle files alongside the video during initial RD `unrestrict()` so their download links are available. RD ignores `selectFiles` on already-downloaded torrents, so the previous dynamic re-selection approach never worked.
- **RD network resilience**: `rdFetch` now retries transient errors (socket resets, timeouts) up to 2x with backoff, has a 15s timeout, and surfaces actual error causes (`UND_ERR_SOCKET`, `ETIMEDOUT`, etc.) instead of generic "fetch failed".
- **Debrid-first priority**: All media endpoints (`/api/subtitle`, `/api/subtitles`, `/api/duration`, `/api/audio-tracks`, `/api/subtitle-extract`) now check debrid before webtorrent, matching the playback flow.
- **Phone remote stale closure fix**: `switchSubtitle` command handler reads from `subsRef` (always current) instead of the `subs` render closure.

## Test plan
- [ ] Play a debrid torrent with external subtitles (e.g. The Boys S01) — subs should load and render
- [ ] Select subtitle from phone remote — should apply on desktop
- [ ] Verify webtorrent subtitle flow still works (non-debrid)
- [ ] Check logs for retry behavior on flaky RD connections