### PR TITLE
feat: auto-recover data on network reconnection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,13 @@ export default function App() {
   useEffect(() => {
     // Phone remote uses the desktop's TMDB key — skip the setup gate
     if (getRemoteSessionId()) { setTmdbReady(true); return; }
-    getTmdbStatus().then((s) => setTmdbReady(s.configured)).catch(() => setTmdbReady(false));
+    const tryStatus = (attempts: number) => {
+      getTmdbStatus().then((s) => setTmdbReady(s.configured)).catch(() => {
+        if (attempts > 1) setTimeout(() => tryStatus(attempts - 1), 1000);
+        else setTmdbReady(false);
+      });
+    };
+    tryStatus(3);
   }, []);
 
   // Intercept external links so they open in the system browser

--- a/src/components/ContentRow.tsx
+++ b/src/components/ContentRow.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import MovieCard from "./MovieCard";
 import { checkAvailability } from "../lib/api";
+import { useRefetchOnRecovery } from "../lib/useRefetchOnRecovery";
 import "./ContentRow.css";
 
 interface ContentRowProps {
@@ -13,7 +14,10 @@ interface ContentRowProps {
 export default function ContentRow({ title, fetchFn, filterAvailability = false }: ContentRowProps) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [items, setItems] = useState<any[] | null>(null);
+  const [recoveryKey, setRecoveryKey] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  useRefetchOnRecovery(useCallback(() => setRecoveryKey((k) => k + 1), []));
 
   useEffect(() => {
     let cancelled = false;
@@ -39,7 +43,7 @@ export default function ContentRow({ title, fetchFn, filterAvailability = false 
       })
       .catch(() => { if (!cancelled) setItems([]); });
     return () => { cancelled = true; };
-  }, [fetchFn]);
+  }, [fetchFn, recoveryKey]);
 
   function scroll(dir: number) {
     const el = scrollRef.current;

--- a/src/components/WatchHistoryRow.tsx
+++ b/src/components/WatchHistoryRow.tsx
@@ -31,8 +31,10 @@ export default function WatchHistoryRow({ title, fetchFn, showProgress = false, 
     };
     load();
     const onCleared = () => { if (!cancelled) load(); };
+    const onRecovery = () => { if (!cancelled) load(); };
     window.addEventListener("storage-cleared", onCleared);
-    return () => { cancelled = true; window.removeEventListener("storage-cleared", onCleared); };
+    window.addEventListener("rattin-network-recovery", onRecovery);
+    return () => { cancelled = true; window.removeEventListener("storage-cleared", onCleared); window.removeEventListener("rattin-network-recovery", onRecovery); };
   }, []);
 
   function scroll(dir: number) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -8,9 +8,31 @@ export const castProfile = (path: string | null): string | null => img(path, "w1
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function get(url: string): Promise<any> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  return res.json();
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    return res.json();
+  } catch (err) {
+    if (err instanceof TypeError) {
+      await new Promise((r) => setTimeout(r, 1000));
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      return res.json();
+    }
+    throw err;
+  }
+}
+
+// ── Network recovery ─────────────────────────────────────────────
+let _recoveryTimer: ReturnType<typeof setTimeout> | null = null;
+if (typeof window !== "undefined") {
+  window.addEventListener("online", () => {
+    if (_recoveryTimer) clearTimeout(_recoveryTimer);
+    _recoveryTimer = setTimeout(() => {
+      _recoveryTimer = null;
+      window.dispatchEvent(new Event("rattin-network-recovery"));
+    }, 2000);
+  });
 }
 
 export function fetchLanIp(): Promise<{ ip: string | null; port: number }> {

--- a/src/lib/useRefetchOnRecovery.ts
+++ b/src/lib/useRefetchOnRecovery.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from "react";
+
+export function useRefetchOnRecovery(callback: () => void): void {
+  const cbRef = useRef(callback);
+  cbRef.current = callback;
+  useEffect(() => {
+    const handler = () => cbRef.current();
+    window.addEventListener("rattin-network-recovery", handler);
+    return () => window.removeEventListener("rattin-network-recovery", handler);
+  }, []);
+}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -65,19 +65,31 @@ export default function Detail() {
   }, [id, type]);
 
   useEffect(() => {
+    let cancelled = false;
     const fetcher = type === "tv" ? fetchTV : fetchMovie;
-    fetcher(id!).then(setData).catch(() => {});
+    fetcher(id!).then((d) => { if (!cancelled) setData(d); }).catch(() => {});
+    return () => { cancelled = true; };
   }, [id, type, recoveryKey]);
 
   useEffect(() => {
-    fetchReviews(type, id!).then(setReviews).catch(() => setReviews({ reviews: [], reddit: [] }));
+    let cancelled = false;
+    fetchReviews(type, id!)
+      .then((r) => { if (!cancelled) setReviews(r); })
+      .catch(() => { if (!cancelled) setReviews({ reviews: [], reddit: [] }); });
+    return () => { cancelled = true; };
   }, [id, type, recoveryKey]);
 
+  // Clear episodes only when navigating or changing season — NOT when `data` is replaced
+  // by a network-recovery refetch (avoids skeleton flash on reconnect)
   useEffect(() => {
-    if (type === "tv" && data) {
-      setEpisodes(null);
-      fetchSeason(id!, selectedSeason).then(setEpisodes).catch(() => {});
-    }
+    setEpisodes(null);
+  }, [id, selectedSeason]);
+
+  useEffect(() => {
+    if (type !== "tv" || !data) return;
+    let cancelled = false;
+    fetchSeason(id!, selectedSeason).then((e) => { if (!cancelled) setEpisodes(e); }).catch(() => {});
+    return () => { cancelled = true; };
   }, [id, selectedSeason, data]);
 
   function refreshResumePoint() {
@@ -94,8 +106,17 @@ export default function Detail() {
   // Fetch resume point and saved state
   useEffect(() => {
     if (!id) return;
-    refreshResumePoint();
-    checkSaved(type, Number(id)).then((r) => setIsSaved(r.saved)).catch(() => {});
+    let cancelled = false;
+    fetchResumePoint(Number(id), type).then((r) => {
+      if (cancelled) return;
+      const point = isValidResumePoint(r.resumePoint, data?.seasons?.filter((s: any) => s.season_number > 0)) ? r.resumePoint : null;
+      setResumePoint(point);
+      if (point?.season && type === "tv" && !sessionStorage.getItem(`season:${id}`)) {
+        setSelectedSeason(point.season);
+      }
+    }).catch(() => {});
+    checkSaved(type, Number(id)).then((r) => { if (!cancelled) setIsSaved(r.saved); }).catch(() => {});
+    return () => { cancelled = true; };
   }, [id, type, recoveryKey]);
 
   // Re-validate resume point when data (seasons) loads
@@ -109,14 +130,17 @@ export default function Detail() {
   // Fetch episode progress for TV
   useEffect(() => {
     if (type !== "tv" || !id) return;
+    let cancelled = false;
     fetchSeriesProgress(Number(id))
       .then((r) => {
+        if (cancelled) return;
         const map = new Map();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         for (const ep of r.episodes) map.set(`s${ep.season}e${ep.episode}`, ep);
         setEpisodeProgress(map);
       })
       .catch(() => {});
+    return () => { cancelled = true; };
   }, [id, type, recoveryKey]);
 
   async function openPicker(season?: number, episode?: number) {

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { fetchMovie, fetchTV, fetchSeason, fetchReviews, autoPlay, searchStreams, playTorrent, backdrop, poster, still, fetchResumePoint, fetchSeriesProgress, checkSaved, toggleSaved, reportWatchProgress, castProfile } from "../lib/api";
 import { ratingColor, formatBytes } from "../lib/utils";
 import { useRemoteMode } from "../lib/PlayerContext";
 import { waitForBridge, mpvSetPoster, mpvSetTitle, mpvSetLoading, mpvSetLoadingStatus } from "../lib/native-bridge";
+import { useRefetchOnRecovery } from "../lib/useRefetchOnRecovery";
 import SourcePicker from "../components/SourcePicker";
 import "./Detail.css";
 
@@ -49,21 +50,28 @@ export default function Detail() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [episodeProgress, setEpisodeProgress] = useState<Map<string, any>>(new Map());
   const [isSaved, setIsSaved] = useState(false);
+  const [recoveryKey, setRecoveryKey] = useState(0);
+  useRefetchOnRecovery(useCallback(() => setRecoveryKey((k) => k + 1), []));
 
+  // Reset visible state on navigation only (not on recovery)
   useEffect(() => {
     setData(null);
     setPlayState(null);
     setCastExpanded(false);
-    const fetcher = type === "tv" ? fetchTV : fetchMovie;
-    fetcher(id!).then(setData).catch(() => {});
-  }, [id, type]);
-
-  useEffect(() => {
     setReviews(null);
     setShowAllReddit(false);
     setShowAllReviews(false);
-    fetchReviews(type, id!).then(setReviews).catch(() => setReviews({ reviews: [], reddit: [] }));
+    setResumePoint(null);
   }, [id, type]);
+
+  useEffect(() => {
+    const fetcher = type === "tv" ? fetchTV : fetchMovie;
+    fetcher(id!).then(setData).catch(() => {});
+  }, [id, type, recoveryKey]);
+
+  useEffect(() => {
+    fetchReviews(type, id!).then(setReviews).catch(() => setReviews({ reviews: [], reddit: [] }));
+  }, [id, type, recoveryKey]);
 
   useEffect(() => {
     if (type === "tv" && data) {
@@ -86,10 +94,9 @@ export default function Detail() {
   // Fetch resume point and saved state
   useEffect(() => {
     if (!id) return;
-    setResumePoint(null);
     refreshResumePoint();
     checkSaved(type, Number(id)).then((r) => setIsSaved(r.saved)).catch(() => {});
-  }, [id, type]);
+  }, [id, type, recoveryKey]);
 
   // Re-validate resume point when data (seasons) loads
   useEffect(() => {
@@ -110,7 +117,7 @@ export default function Detail() {
         setEpisodeProgress(map);
       })
       .catch(() => {});
-  }, [id, type]);
+  }, [id, type, recoveryKey]);
 
   async function openPicker(season?: number, episode?: number) {
     setPickerSeason(season);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import WatchHistoryRow from "../components/WatchHistoryRow";
 import { fetchTrending, fetchDiscover, fetchGenres, fetchContinueWatching, dismissWatchHistory, autoPlay, poster as posterUrl } from "../lib/api";
 import { waitForBridge, mpvSetPoster, mpvSetTitle, mpvSetLoading, mpvSetLoadingStatus } from "../lib/native-bridge";
 import { useRemoteMode } from "../lib/PlayerContext";
+import { useRefetchOnRecovery } from "../lib/useRefetchOnRecovery";
 import "./Home.css";
 
 function recentDateRange() {
@@ -36,7 +37,7 @@ export default function Home() {
     ? withoutAmpersand.filter((g) => g.name.toLowerCase().includes(genreFilter.toLowerCase()))
     : withoutAmpersand;
 
-  useEffect(() => {
+  const loadHomeData = useCallback(() => {
     fetchTrending().then((data) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const items = (data.results || []).filter((i: any) => i.backdrop_path && i.overview);
@@ -44,6 +45,9 @@ export default function Home() {
     }).catch(() => {});
     fetchGenres().then((data) => setGenres(data.genres || [])).catch(() => {});
   }, []);
+
+  useEffect(() => { loadHomeData(); }, [loadHomeData]);
+  useRefetchOnRecovery(loadHomeData);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleContinuePlay = useCallback(async (item: any) => {

--- a/src/pages/MyList.tsx
+++ b/src/pages/MyList.tsx
@@ -27,7 +27,8 @@ export default function MyList() {
 
   useEffect(() => {
     window.addEventListener("storage-cleared", loadItems);
-    return () => window.removeEventListener("storage-cleared", loadItems);
+    window.addEventListener("rattin-network-recovery", loadItems);
+    return () => { window.removeEventListener("storage-cleared", loadItems); window.removeEventListener("rattin-network-recovery", loadItems); };
   }, []);
 
   function handleRemove(item: SavedItem) {

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import MovieCard from "../components/MovieCard";
 import { searchTMDB, fetchDiscover } from "../lib/api";
+import { useRefetchOnRecovery } from "../lib/useRefetchOnRecovery";
 import "./Search.css";
 
 export default function Search() {
@@ -17,6 +18,8 @@ export default function Search() {
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const queryKey = useRef("");
+  const [recoveryKey, setRecoveryKey] = useState(0);
+  useRefetchOnRecovery(useCallback(() => { queryKey.current = ""; setRecoveryKey((k) => k + 1); }, []));
 
   // Reset on query/genre change
   useEffect(() => {
@@ -42,7 +45,7 @@ export default function Search() {
       setResults(filtered);
       setHasMore((data.page || 1) < (data.total_pages || 1));
     }).catch(() => setResults([]));
-  }, [q, genre, mediaType]);
+  }, [q, genre, mediaType, recoveryKey]);
 
   function loadMore() {
     const nextPage = page + 1;

--- a/test/lib/api.test.ts
+++ b/test/lib/api.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { fetchGenres } from "../../src/lib/api.js";
+
+describe("api.get() retry primitive", () => {
+  let origFetch: typeof globalThis.fetch;
+  let calls: number;
+
+  beforeEach(() => {
+    origFetch = globalThis.fetch;
+    calls = 0;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it("retries exactly once on TypeError (network error)", async () => {
+    globalThis.fetch = (async () => {
+      calls++;
+      if (calls === 1) throw new TypeError("Failed to fetch");
+      return new Response(JSON.stringify({ genres: [] }), { status: 200 });
+    }) as typeof globalThis.fetch;
+    const result = await fetchGenres();
+    assert.equal(calls, 2, "should have called fetch twice (initial + 1 retry)");
+    assert.deepEqual(result, { genres: [] });
+  });
+
+  it("does NOT retry on HTTP errors (4xx/5xx)", async () => {
+    globalThis.fetch = (async () => {
+      calls++;
+      return new Response("", { status: 404, statusText: "Not Found" });
+    }) as typeof globalThis.fetch;
+    await assert.rejects(() => fetchGenres(), /404/);
+    assert.equal(calls, 1, "HTTP errors must not trigger a retry");
+  });
+
+  it("does NOT retry on non-TypeError exceptions (e.g. AbortError)", async () => {
+    globalThis.fetch = (async () => {
+      calls++;
+      throw new DOMException("aborted", "AbortError");
+    }) as typeof globalThis.fetch;
+    await assert.rejects(() => fetchGenres());
+    assert.equal(calls, 1, "AbortError must not trigger a retry");
+  });
+
+  it("gives up after one retry if TypeError persists", async () => {
+    globalThis.fetch = (async () => {
+      calls++;
+      throw new TypeError("Failed to fetch");
+    }) as typeof globalThis.fetch;
+    await assert.rejects(() => fetchGenres(), TypeError);
+    assert.equal(calls, 2, "exactly two total attempts — no unbounded retry");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds automatic data recovery when internet connectivity is restored — all pages refetch within ~3s without app restart
- `get()` in api.ts retries once (1s delay) on network errors (TypeError only, not HTTP errors); browser `online` event dispatches a debounced `rattin-network-recovery` custom event (2s debounce)
- New `useRefetchOnRecovery` hook wired into Home, ContentRow, WatchHistoryRow, Detail, Search, MyList, and App.tsx startup gate (3 retries)

## Test plan

- [ ] `npm run build` passes (verified ✅)
- [ ] `npm test` — 310 pass, 6 fail (pre-existing TMDB route failures only, verified ✅)
- [ ] No forbidden files touched: Player, Navbar, Remote, backend — verified ✅
- [ ] Manual: start app offline → restore internet → Home populates within ~3s
- [ ] Manual: Home loaded → disconnect → reconnect → all ContentRows repopulate
- [ ] Manual: Detail page skeleton (failed load) → reconnect → data appears without flash
- [ ] Manual: Search "No results" from network error → reconnect → results appear
- [ ] Manual: MyList empty from error → reconnect → list appears
- [ ] Manual: verify no visible change when network is stable (happy path identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)