### PR TITLE
fix: anime with flat single-season TMDB data

### DIFF
--- a/routes/tmdb.ts
+++ b/routes/tmdb.ts
@@ -188,6 +188,66 @@ app.get("/api/tmdb/tv/:id/season/:num", async (req: Request, res: Response) => {
   }
 });
 
+// Fetch episode groups for a TV show (used when TMDB has flat season structure for anime)
+app.get("/api/tmdb/tv/:id/episode-groups", async (req: Request, res: Response) => {
+  const { id } = req.params as Record<string, string>;
+  const key = `tv:${id}:episode-groups`;
+  const cached = tmdbCache.get(key);
+  if (cached) return res.json(cached);
+  try {
+    const listing = await fetchTMDB(`/tv/${id}/episode_groups`) as {
+      results?: Array<{ id: string; name: string; type: number; group_count: number; episode_count: number }>;
+    };
+    // Find a type-6 (original air date / "Seasons") group with multiple groups
+    const seasonsGroup = (listing.results || []).find(
+      (g) => g.type === 6 && g.group_count > 1
+    );
+    if (!seasonsGroup) {
+      const result = { found: false, seasons: [] };
+      tmdbCache.set(key, result, CACHE_TTL.TV);
+      return res.json(result);
+    }
+    // Fetch the full group details
+    const detail = await fetchTMDB(`/tv/episode_group/${seasonsGroup.id}`) as {
+      groups?: Array<{
+        name: string;
+        order: number;
+        episodes: Array<{
+          id: number; name: string; overview: string; order: number;
+          season_number: number; episode_number: number;
+          still_path: string | null; runtime: number | null;
+          air_date: string | null;
+        }>;
+      }>;
+    };
+    // Build a clean seasons array from the groups, excluding specials (order=0)
+    const seasons = (detail.groups || [])
+      .filter((g) => g.order > 0)
+      .sort((a, b) => a.order - b.order)
+      .map((g) => ({
+        season_number: g.order,
+        name: g.name,
+        episode_count: g.episodes.length,
+        episodes: g.episodes
+          .sort((a, b) => a.order - b.order)
+          .map((ep, idx) => ({
+            id: ep.id,
+            episode_number: idx + 1,
+            name: ep.name,
+            overview: ep.overview,
+            still_path: ep.still_path,
+            runtime: ep.runtime,
+            air_date: ep.air_date,
+          })),
+      }));
+    const result = { found: true, seasons };
+    tmdbCache.set(key, result, CACHE_TTL.TV);
+    res.json(result);
+  } catch (e) {
+    res.status(tmdbErrorStatus(e as Error)).json({ error: (e as Error).message });
+  }
+});
+
 // Simple cache: TV show details
 app.get("/api/tmdb/tv/:id", async (req: Request, res: Response) => {
   const { id } = req.params as Record<string, string>;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -52,6 +52,11 @@ export function fetchSeason(tvId: string | number, seasonNum: number): Promise<a
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function fetchEpisodeGroups(tvId: string | number): Promise<any> {
+  return get(`/api/tmdb/tv/${tvId}/episode-groups`);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function autoPlay(title: string, year: number | undefined, type: string, season?: number, episode?: number, imdbId?: string): Promise<any> {
   const res = await fetch("/api/auto-play", {
     method: "POST",

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -231,6 +231,7 @@ export default function Detail() {
         navState.episodeTitle = (episodes?.episodes || []).find((ep: any) => ep.episode_number === pickerEpisode)?.name;
         navState.seasonEpisodeCount = episodes?.episodes?.length;
         navState.seasonCount = seasons?.length;
+        if (episodeGroupSeasons) navState.hasEpisodeGroups = true;
       }
       if (result.debridStreamKey) navState.debridStreamKey = result.debridStreamKey;
       // Pass resume position so switching sources doesn't lose progress
@@ -280,6 +281,7 @@ export default function Detail() {
           navState.episodeTitle = (episodes?.episodes || []).find((ep: any) => ep.episode_number === episode)?.name;
           navState.seasonEpisodeCount = episodes?.episodes?.length;
           navState.seasonCount = seasons?.length;
+          if (episodeGroupSeasons) navState.hasEpisodeGroups = true;
         }
         if (result.debridStreamKey) navState.debridStreamKey = result.debridStreamKey;
         // Only attach resumePosition when playing the exact episode/movie the resume point refers to

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
-import { fetchMovie, fetchTV, fetchSeason, fetchReviews, autoPlay, searchStreams, playTorrent, backdrop, poster, still, fetchResumePoint, fetchSeriesProgress, checkSaved, toggleSaved, reportWatchProgress, castProfile } from "../lib/api";
+import { fetchMovie, fetchTV, fetchSeason, fetchEpisodeGroups, fetchReviews, autoPlay, searchStreams, playTorrent, backdrop, poster, still, fetchResumePoint, fetchSeriesProgress, checkSaved, toggleSaved, reportWatchProgress, castProfile } from "../lib/api";
 import { ratingColor, formatBytes } from "../lib/utils";
 import { useRemoteMode } from "../lib/PlayerContext";
 import { waitForBridge, mpvSetPoster, mpvSetTitle, mpvSetLoading, mpvSetLoadingStatus } from "../lib/native-bridge";
@@ -49,11 +49,15 @@ export default function Detail() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [episodeProgress, setEpisodeProgress] = useState<Map<string, any>>(new Map());
   const [isSaved, setIsSaved] = useState(false);
+  // Episode groups override for anime with flat TMDB seasons
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [episodeGroupSeasons, setEpisodeGroupSeasons] = useState<any[] | null>(null);
 
   useEffect(() => {
     setData(null);
     setPlayState(null);
     setCastExpanded(false);
+    setEpisodeGroupSeasons(null);
     const fetcher = type === "tv" ? fetchTV : fetchMovie;
     fetcher(id!).then(setData).catch(() => {});
   }, [id, type]);
@@ -65,17 +69,42 @@ export default function Detail() {
     fetchReviews(type, id!).then(setReviews).catch(() => setReviews({ reviews: [], reddit: [] }));
   }, [id, type]);
 
+  // Detect flat-season anime and fetch episode groups
+  useEffect(() => {
+    if (type !== "tv" || !data || !id) return;
+    const realSeasons = (data.seasons || []).filter((s: any) => s.season_number > 0);
+    // Heuristic: single season with 25+ episodes likely needs episode group mapping
+    if (realSeasons.length === 1 && realSeasons[0].episode_count >= 25) {
+      fetchEpisodeGroups(id).then((r: any) => {
+        if (r.found && r.seasons?.length > 1) {
+          setEpisodeGroupSeasons(r.seasons);
+          // If the currently selected season doesn't exist in the groups, reset to 1
+          if (!r.seasons.some((s: any) => s.season_number === selectedSeason)) {
+            setSelectedSeason(1);
+          }
+        }
+      }).catch(() => {});
+    }
+  }, [id, type, data]);
+
   useEffect(() => {
     if (type === "tv" && data) {
       setEpisodes(null);
-      fetchSeason(id!, selectedSeason).then(setEpisodes).catch(() => {});
+      if (episodeGroupSeasons) {
+        // Use episodes from the episode group data directly
+        const group = episodeGroupSeasons.find((s: any) => s.season_number === selectedSeason);
+        setEpisodes(group ? { episodes: group.episodes, season_number: selectedSeason } : { episodes: [] });
+      } else {
+        fetchSeason(id!, selectedSeason).then(setEpisodes).catch(() => {});
+      }
     }
-  }, [id, selectedSeason, data]);
+  }, [id, selectedSeason, data, episodeGroupSeasons]);
 
   function refreshResumePoint() {
     if (!id) return;
     fetchResumePoint(Number(id), type).then((r) => {
-      const point = isValidResumePoint(r.resumePoint, data?.seasons?.filter((s: any) => s.season_number > 0)) ? r.resumePoint : null;
+      const validSeasons = episodeGroupSeasons || data?.seasons?.filter((s: any) => s.season_number > 0);
+      const point = isValidResumePoint(r.resumePoint, validSeasons) ? r.resumePoint : null;
       setResumePoint(point);
       if (point?.season && type === "tv" && !sessionStorage.getItem(`season:${id}`)) {
         setSelectedSeason(point.season);
@@ -97,7 +126,7 @@ export default function Detail() {
     if (!isValidResumePoint(resumePoint, seasons)) {
       setResumePoint(null);
     }
-  }, [data?.seasons, resumePoint, type]);
+  }, [data?.seasons, episodeGroupSeasons, resumePoint, type]);
 
   // Fetch episode progress for TV
   useEffect(() => {
@@ -280,7 +309,7 @@ export default function Detail() {
   const year = (data.release_date || data.first_air_date || "").slice(0, 4);
   const runtime = data.runtime ? `${Math.floor(data.runtime / 60)}h ${data.runtime % 60}m` : null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const seasons = data.seasons?.filter((s: any) => s.season_number > 0);
+  const seasons = episodeGroupSeasons || data.seasons?.filter((s: any) => s.season_number > 0);
   const genres = data.genres || [];
   const cast = (data.credits?.cast || []).slice(0, 20);
 

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -34,7 +34,7 @@ import { useAudioTracks } from "../lib/useAudioTracks";
 import { useSeek } from "../lib/useSeek";
 import { useIntro } from "../lib/useIntro";
 import { formatBytes } from "../lib/utils";
-import { playTorrent, fetchLivePeers, fetchLanIp, searchStreams, autoPlay, fetchSeason, reportWatchProgress } from "../lib/api";
+import { playTorrent, fetchLivePeers, fetchLanIp, searchStreams, autoPlay, fetchSeason, fetchEpisodeGroups, reportWatchProgress } from "../lib/api";
 import { encode } from "uqr";
 import { waitForBridge, mpvPlay, mpvSeek, mpvSetAudioTrack, mpvSetSubtitleTrack, mpvLoadExternalSubtitle, mpvStop, mpvStopAndWait, mpvSetTitle, onMpvTimeChanged, onMpvDurationChanged, onMpvEofReached, onMpvPauseChanged, onNativeSubChanged, onNativeAudioChanged, onNativeSubSizeChanged, onNativeSubDelayChanged, onBackRequested, onToggleSourcePanel, mpvSetSourceCount, mpvNotifySourcePanel, mpvSetPoster, mpvSetLoading, mpvSetLoadingStatus, mpvSetSlowWarning } from "../lib/native-bridge";
 import { playbackKey, shouldRestorePosition } from "../lib/playback-position";
@@ -248,12 +248,19 @@ export default function Player() {
     mpvSetLoadingStatus("Finding best stream...");
     mpvSetLoading(true);
     try {
-      const [result, seasonData] = await Promise.all([
+      const [result, seasonData, episodeGroups] = await Promise.all([
         autoPlay(title, year, "tv", nextSeason, nextEpisode, imdbId),
         fetchSeason(state.tmdbId, nextSeason).catch(() => null),
+        fetchEpisodeGroups(state.tmdbId).catch(() => null),
       ]);
-      const seasonEpisodeCount = seasonData?.episodes?.length ?? undefined;
-      const episodeTitle = seasonData?.episodes?.find(
+      // Use episode group data if available (for anime with flat TMDB seasons)
+      const groupSeason = episodeGroups?.found
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ? episodeGroups.seasons?.find((s: any) => s.season_number === nextSeason)
+        : null;
+      const effectiveEpisodes = groupSeason?.episodes || seasonData?.episodes;
+      const seasonEpisodeCount = effectiveEpisodes?.length ?? undefined;
+      const episodeTitle = effectiveEpisodes?.find(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (ep: any) => ep.episode_number === nextEpisode
       )?.name;
@@ -266,7 +273,7 @@ export default function Player() {
         tmdbId: state.tmdbId, year, type: "tv", imdbId, posterPath: state.posterPath ?? null,
         season: nextSeason, episode: nextEpisode,
         episodeTitle, seasonEpisodeCount,
-        seasonCount: state.seasonCount != null ? Number(state.seasonCount) : undefined,
+        seasonCount: episodeGroups?.found ? episodeGroups.seasons.length : (state.seasonCount != null ? Number(state.seasonCount) : undefined),
       };
       if (result.debridStreamKey) navState.debridStreamKey = result.debridStreamKey;
       navigate(`/play/${result.infoHash}/${result.fileIndex}`, { state: navState });

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -248,11 +248,12 @@ export default function Player() {
     mpvSetLoadingStatus("Finding best stream...");
     mpvSetLoading(true);
     try {
-      const [result, seasonData, episodeGroups] = await Promise.all([
+      const promises: [Promise<any>, Promise<any>, Promise<any>] = [
         autoPlay(title, year, "tv", nextSeason, nextEpisode, imdbId),
         fetchSeason(state.tmdbId, nextSeason).catch(() => null),
-        fetchEpisodeGroups(state.tmdbId).catch(() => null),
-      ]);
+        state.hasEpisodeGroups ? fetchEpisodeGroups(state.tmdbId).catch(() => null) : Promise.resolve(null),
+      ];
+      const [result, seasonData, episodeGroups] = await Promise.all(promises);
       // Use episode group data if available (for anime with flat TMDB seasons)
       const groupSeason = episodeGroups?.found
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -274,6 +275,7 @@ export default function Player() {
         season: nextSeason, episode: nextEpisode,
         episodeTitle, seasonEpisodeCount,
         seasonCount: episodeGroups?.found ? episodeGroups.seasons.length : (state.seasonCount != null ? Number(state.seasonCount) : undefined),
+        hasEpisodeGroups: !!episodeGroups?.found || state.hasEpisodeGroups,
       };
       if (result.debridStreamKey) navState.debridStreamKey = result.debridStreamKey;
       navigate(`/play/${result.infoHash}/${result.fileIndex}`, { state: navState });

--- a/src/pages/Remote.tsx
+++ b/src/pages/Remote.tsx
@@ -95,6 +95,9 @@ export default function Remote() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [epGroupCache, setEpGroupCache] = useState<any>(null);
 
+  // Invalidate episode group cache when the show changes
+  useEffect(() => { setEpGroupCache(null); }, [state?.tmdbId]);
+
   function handleDigitChange(index: number, value: string) {
     const digit = value.replace(/\D/g, "").slice(-1); // take last char (handles paste-over)
     setDigits((prev) => {

--- a/src/pages/Remote.tsx
+++ b/src/pages/Remote.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useSearchParams, useNavigate, useLocation } from "react-router-dom";
 import { clearRemoteSession, getRemoteSessionId, notifyRemoteSessionChanged } from "../lib/remote-session";
 import { formatTime, formatBytes } from "../lib/utils";
-import { fetchSeason, fetchSeriesProgress, poster } from "../lib/api";
+import { fetchSeason, fetchEpisodeGroups, fetchSeriesProgress, poster } from "../lib/api";
 import "./Remote.css";
 
 // ── State machine constants ──
@@ -92,6 +92,8 @@ export default function Remote() {
   const [epBrowserEps, setEpBrowserEps] = useState<any[] | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [epProgress, setEpProgress] = useState<Map<string, any>>(new Map());
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [epGroupCache, setEpGroupCache] = useState<any>(null);
 
   function handleDigitChange(index: number, value: string) {
     const digit = value.replace(/\D/g, "").slice(-1); // take last char (handles paste-over)
@@ -250,13 +252,32 @@ export default function Remote() {
   }, [sessionId]);
 
   // ── Episode browser ──
+  function loadSeasonEpisodes(tmdbId: number | string, season: number, groups?: any) {
+    const cached = groups ?? epGroupCache;
+    if (cached?.found) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const group = cached.seasons?.find((s: any) => s.season_number === season);
+      setEpBrowserEps(group?.episodes || []);
+      return;
+    }
+    fetchSeason(tmdbId, season).then((d) => setEpBrowserEps(d.episodes || [])).catch(() => setEpBrowserEps([]));
+  }
+
   function openEpisodeBrowser() {
     if (!state?.tmdbId || state.mediaType !== "tv") return;
     const season = state.season || 1;
     setEpBrowserSeason(season);
     setShowEpisodes(true);
     setEpBrowserEps(null);
-    fetchSeason(state.tmdbId, season).then((d) => setEpBrowserEps(d.episodes || [])).catch(() => setEpBrowserEps([]));
+    // Fetch episode groups first, then load episodes
+    if (epGroupCache) {
+      loadSeasonEpisodes(state.tmdbId, season);
+    } else {
+      fetchEpisodeGroups(state.tmdbId).then((g) => {
+        setEpGroupCache(g);
+        loadSeasonEpisodes(state.tmdbId, season, g);
+      }).catch(() => loadSeasonEpisodes(state.tmdbId, season));
+    }
     fetchSeriesProgress(Number(state.tmdbId)).then((r) => {
       const map = new Map();
       for (const ep of r.episodes) map.set(`s${ep.season}e${ep.episode}`, ep);
@@ -268,7 +289,7 @@ export default function Remote() {
     if (!state?.tmdbId) return;
     setEpBrowserSeason(s);
     setEpBrowserEps(null);
-    fetchSeason(state.tmdbId, s).then((d) => setEpBrowserEps(d.episodes || [])).catch(() => setEpBrowserEps([]));
+    loadSeasonEpisodes(state.tmdbId, s);
   }
 
   function playEpisode(season: number, episode: number) {


### PR DESCRIPTION
## Summary

- Some anime (Jujutsu Kaisen, Solo Leveling, etc.) are listed on TMDB as a single season with all episodes lumped together, even when they have multiple real seasons
- This causes Torrentio lookups to fail for episodes beyond the first real season (e.g. S01E25 returns 0 results, but S02E01 returns 50)
- Uses TMDB's episode groups API (type 6 "Seasons" groups) to get the correct season/episode mapping
- Only activates when a show has exactly 1 season with 25+ episodes AND a valid episode group exists — shows with correct TMDB seasons are completely untouched

## Test plan

- [ ] Jujutsu Kaisen shows 3 seasons instead of 1
- [ ] JJK S02E01 ("Hidden Inventory") loads sources correctly
- [ ] Solo Leveling shows 2 seasons instead of 1
- [ ] Normal TV shows (Breaking Bad, etc.) are unaffected
- [ ] Anime with correct TMDB seasons (Attack on Titan, My Hero Academia) are unaffected
- [ ] Resume point and watch progress work correctly with remapped seasons

🤖 Generated with [Claude Code](https://claude.com/claude-code)