### PR TITLE
feat: IntroDB markers, episode-markers API, and remote UI rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Rattin is a single desktop app that does all of it — browse TMDB, click play, 
 
 🎬 Every codec, every container, every format — played natively through libmpv with hardware decoding<br>
 ⏩ Smart seeking in incomplete files — jump anywhere, even before it's downloaded<br>
+🍿 One-tap binge mode — auto-skip intros and credits, auto-advance to the next episode, and keep your audio/subtitle picks across a whole show (AniSkip + IntroDB, plus credits learned from your own watching)<br>
 🔍 TMDB discovery — trending, genres, search, trailers, cast, one-click play<br>
 📱 Phone remote via QR scan — no app install, just point your camera<br>
 🔒 No account, no database, no cloud, no telemetry — nothing leaves your machine<br>
@@ -58,6 +59,7 @@ Rattin is a single desktop app that does all of it — browse TMDB, click play, 
 - **Full control** - Play, pause, seek, volume, subtitles, audio tracks
 - **Browse from your phone** - Search and start content from the couch
 - **Real-time sync** - Player and remote stay in lockstep
+- **Binge mode** - One tap enables auto-skip intros and credits, auto-advance to the next episode, and persistent audio/subtitle tracks for the rest of the show. Intro and credit markers come from AniSkip and IntroDB, with outros also learned from your own watching when no public data exists.
 
 ### :shield: Privacy
 

--- a/lib/media/anime-detect.ts
+++ b/lib/media/anime-detect.ts
@@ -1,0 +1,32 @@
+import { fetchTMDB, tmdbCache, CACHE_TTL } from "../cache/cache.js";
+
+type TmdbFetcherFn = (path: string) => Promise<unknown>;
+
+let _fetcher: TmdbFetcherFn | null = null;
+
+export function _setTmdbFetcher(fn: TmdbFetcherFn | null): void { _fetcher = fn; }
+function getFetcher(): TmdbFetcherFn { return _fetcher || fetchTMDB; }
+
+interface TmdbTvDetail {
+  origin_country?: string[];
+  genres?: Array<{ id: number; name: string }>;
+}
+
+const ANIMATION_GENRE_ID = 16;
+
+export async function isAnime(tmdbId: string): Promise<boolean> {
+  const cacheKey = `anime:${tmdbId}`;
+  const cached = tmdbCache.get(cacheKey);
+  if (typeof cached === "boolean") return cached;
+
+  try {
+    const data = await getFetcher()(`/tv/${tmdbId}`) as TmdbTvDetail;
+    const jp = Array.isArray(data.origin_country) && data.origin_country.includes("JP");
+    const animation = Array.isArray(data.genres) && data.genres.some((g) => g?.id === ANIMATION_GENRE_ID);
+    const result = jp && animation;
+    tmdbCache.set(cacheKey, result, CACHE_TTL.TV);
+    return result;
+  } catch {
+    return false;
+  }
+}

--- a/lib/media/episode-markers.ts
+++ b/lib/media/episode-markers.ts
@@ -2,12 +2,20 @@ import type { MarkerSource } from "../types.js";
 
 export interface ChapterInput { time: number; title: string }
 export interface AniskipInput { opStart: number; opEnd: number; edStart: number; episodeLength: number }
+export interface IntrodbInput {
+  introStart: number | null;
+  introEnd: number | null;
+  outroStart: number | null;
+  introSubmissionCount: number;
+  outroSubmissionCount: number;
+}
 export interface LearnedOffsetInput { offset: number; sampleCount: number }
 
 export interface MarkerInputs {
   bridgeHasChapterSupport: boolean;
   chapters: ChapterInput[];
   aniskip: AniskipInput | null;
+  introdb: IntrodbInput | null;
   learnedOutroOffset: LearnedOffsetInput | null;
   fileDuration: number;
 }
@@ -55,31 +63,74 @@ export function computeMarkers(input: MarkerInputs): Markers {
 }
 
 function afterChapters(input: MarkerInputs, prior: Markers): Markers {
+  let partial = prior;
+
   if (input.aniskip) {
     const mismatch = Math.abs(input.fileDuration - input.aniskip.episodeLength) > 30;
     if (mismatch) {
-      return afterAniskip(input, {
-        ...prior,
+      partial = {
+        ...partial,
         introSource: "AniSkip · duration mismatch",
         outroSource: "AniSkip · duration mismatch",
-      });
+      };
+    } else {
+      // Treat 0 as missing — AniSkip wire format uses 0 as "segment absent" sentinel.
+      const opPresent = input.aniskip.opStart > 0 || input.aniskip.opEnd > 0;
+      const edPresent = input.aniskip.edStart > 0;
+      partial = {
+        introStart: opPresent ? input.aniskip.opStart : null,
+        introEnd: opPresent ? input.aniskip.opEnd : null,
+        outroStart: edPresent ? input.aniskip.edStart : null,
+        introSource: opPresent ? "AniSkip · duration OK" : "no AniSkip data",
+        outroSource: edPresent ? "AniSkip · duration OK" : "no AniSkip data",
+      };
     }
-    return {
-      introStart: input.aniskip.opStart,
-      introEnd: input.aniskip.opEnd,
-      outroStart: input.aniskip.edStart,
-      introSource: "AniSkip · duration OK",
-      outroSource: "AniSkip · duration OK",
-    };
   }
-  return afterAniskip(input, {
-    ...prior,
-    introSource: prior.introSource !== "no chapter data" ? prior.introSource : "no AniSkip data",
-    outroSource: prior.outroSource !== "no chapter data" ? prior.outroSource : "no AniSkip data",
-  });
+
+  // IntroDB fills whichever axes are still null (never overrides an already-resolved value
+  // or a meaningful source string like "AniSkip · duration mismatch").
+  if (input.introdb) {
+    const introFromIntrodb = partial.introStart === null
+      && input.introdb.introStart !== null
+      && input.introdb.introEnd !== null
+      && input.introdb.introSubmissionCount >= 2;
+    const outroFromIntrodb = partial.outroStart === null
+      && input.introdb.outroStart !== null
+      && input.introdb.outroSubmissionCount >= 2;
+    if (introFromIntrodb) {
+      partial = {
+        ...partial,
+        introStart: input.introdb.introStart,
+        introEnd: input.introdb.introEnd,
+        introSource: "IntroDB · ok",
+      };
+    }
+    if (outroFromIntrodb) {
+      partial = {
+        ...partial,
+        outroStart: input.introdb.outroStart,
+        outroSource: "IntroDB · ok",
+      };
+    }
+  }
+
+  // Relabel unresolved fall-through sources so diagnostics reflect the deepest source tried.
+  // Only overwrite the generic "no chapter data" / "no AniSkip data" placeholders; preserve
+  // specific signals like "AniSkip · duration mismatch" and "bridge missing chapter support".
+  const relabelable: MarkerSource[] = ["no chapter data", "no AniSkip data"];
+  if (partial.introStart === null && relabelable.includes(partial.introSource)) {
+    partial = { ...partial, introSource: "no IntroDB data" };
+  }
+  if (partial.outroStart === null && relabelable.includes(partial.outroSource)) {
+    partial = { ...partial, outroSource: "no IntroDB data" };
+  }
+
+  return afterRemote(input, partial);
 }
 
-function afterAniskip(input: MarkerInputs, prior: Markers): Markers {
+function afterRemote(input: MarkerInputs, prior: Markers): Markers {
+  // Preserve pre-existing behavior: learnedOutroOffset, when present, always wins for outro.
+  // This is intentional — the learned offset is per-user-per-show and reflects actual viewing.
   if (input.learnedOutroOffset) {
     return {
       ...prior,
@@ -88,8 +139,8 @@ function afterAniskip(input: MarkerInputs, prior: Markers): Markers {
       outroSampleCount: input.learnedOutroOffset.sampleCount,
     };
   }
-  return {
-    ...prior,
-    outroSource: "no signal — advance on EOF",
-  };
+  if (prior.outroStart === null && prior.outroSource !== "AniSkip · duration mismatch") {
+    return { ...prior, outroSource: "no signal — advance on EOF" };
+  }
+  return prior;
 }

--- a/lib/media/episode-markers.ts
+++ b/lib/media/episode-markers.ts
@@ -92,11 +92,9 @@ function afterChapters(input: MarkerInputs, prior: Markers): Markers {
   if (input.introdb) {
     const introFromIntrodb = partial.introStart === null
       && input.introdb.introStart !== null
-      && input.introdb.introEnd !== null
-      && input.introdb.introSubmissionCount >= 2;
+      && input.introdb.introEnd !== null;
     const outroFromIntrodb = partial.outroStart === null
-      && input.introdb.outroStart !== null
-      && input.introdb.outroSubmissionCount >= 2;
+      && input.introdb.outroStart !== null;
     if (introFromIntrodb) {
       partial = {
         ...partial,

--- a/lib/media/introdb.ts
+++ b/lib/media/introdb.ts
@@ -1,6 +1,8 @@
 // IntroDB client — crowdsourced intro/outro timestamps keyed by IMDb ID + season + episode.
 // See https://introdb.app / OpenAPI at https://api.introdb.app/openapi.json
 
+import type { LogFn } from "../types.js";
+
 type FetcherFn = typeof globalThis.fetch;
 
 let _fetcher: FetcherFn | null = null;
@@ -11,6 +13,8 @@ function getFetcher(): FetcherFn { return _fetcher || globalThis.fetch; }
 const INTRODB_BASE = "https://api.introdb.app";
 const SUBMISSION_FLOOR = 2;
 const FETCH_TIMEOUT_MS = 5000;
+
+const noopLog: LogFn = () => {};
 
 export interface IntrodbSegment {
   startSec: number;
@@ -55,31 +59,32 @@ export async function lookupIntrodbMarkers(
   imdbId: string,
   season: number,
   episode: number,
+  log: LogFn = noopLog,
 ): Promise<IntrodbMarkers | null> {
   const doFetch = getFetcher();
   const url = `${INTRODB_BASE}/segments?imdb_id=${encodeURIComponent(imdbId)}&season=${season}&episode=${episode}`;
-  console.info("[introdb] GET", url);
+  log("info", "[introdb] GET", { url });
   try {
     const res = await doFetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
     if (!res.ok) {
-      console.info("[introdb] non-ok response", { url, status: res.status });
+      log("info", "[introdb] non-ok response", { url, status: res.status });
       return null;
     }
     const data = await res.json() as ApiResponse;
-    console.info("[introdb] raw response", {
+    log("info", "[introdb] raw response", {
       imdb_id: data.imdb_id, intro: data.intro, outro: data.outro, recap: data.recap,
     });
     const intro = normalizeSegment(data.intro);
     const outro = normalizeSegment(data.outro);
     if (!intro && !outro) {
-      console.info("[introdb] both segments rejected by floor/shape", {
+      log("info", "[introdb] both segments rejected by floor/shape", {
         introRaw: data.intro, outroRaw: data.outro, floor: SUBMISSION_FLOOR,
       });
       return null;
     }
     return { intro, outro, imdbId };
   } catch (err) {
-    console.info("[introdb] fetch threw", { url, error: (err as Error).message });
+    log("info", "[introdb] fetch threw", { url, error: (err as Error).message });
     return null;
   }
 }

--- a/lib/media/introdb.ts
+++ b/lib/media/introdb.ts
@@ -1,0 +1,72 @@
+// IntroDB client — crowdsourced intro/outro timestamps keyed by IMDb ID + season + episode.
+// See https://introdb.app / OpenAPI at https://api.introdb.app/openapi.json
+
+type FetcherFn = typeof globalThis.fetch;
+
+let _fetcher: FetcherFn | null = null;
+
+export function _setFetcher(fn: FetcherFn | null): void { _fetcher = fn; }
+function getFetcher(): FetcherFn { return _fetcher || globalThis.fetch; }
+
+const INTRODB_BASE = "https://api.introdb.app";
+const SUBMISSION_FLOOR = 2;
+const FETCH_TIMEOUT_MS = 5000;
+
+export interface IntrodbSegment {
+  startSec: number;
+  endSec: number;
+  confidence: number;
+  submissionCount: number;
+}
+
+export interface IntrodbMarkers {
+  intro: IntrodbSegment | null;
+  outro: IntrodbSegment | null;
+  imdbId: string;
+}
+
+interface ApiSegment {
+  start_sec?: number;
+  end_sec?: number;
+  confidence?: number;
+  submission_count?: number;
+}
+interface ApiResponse {
+  imdb_id?: string;
+  intro?: ApiSegment | null;
+  outro?: ApiSegment | null;
+  recap?: ApiSegment | null;
+}
+
+function normalizeSegment(s: ApiSegment | null | undefined): IntrodbSegment | null {
+  if (!s) return null;
+  const count = s.submission_count ?? 0;
+  if (count < SUBMISSION_FLOOR) return null;
+  if (typeof s.start_sec !== "number" || typeof s.end_sec !== "number") return null;
+  return {
+    startSec: s.start_sec,
+    endSec: s.end_sec,
+    confidence: s.confidence ?? 0,
+    submissionCount: count,
+  };
+}
+
+export async function lookupIntrodbMarkers(
+  imdbId: string,
+  season: number,
+  episode: number,
+): Promise<IntrodbMarkers | null> {
+  const doFetch = getFetcher();
+  const url = `${INTRODB_BASE}/segments?imdb_id=${encodeURIComponent(imdbId)}&season=${season}&episode=${episode}`;
+  try {
+    const res = await doFetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (!res.ok) return null;
+    const data = await res.json() as ApiResponse;
+    const intro = normalizeSegment(data.intro);
+    const outro = normalizeSegment(data.outro);
+    if (!intro && !outro) return null;
+    return { intro, outro, imdbId };
+  } catch {
+    return null;
+  }
+}

--- a/lib/media/introdb.ts
+++ b/lib/media/introdb.ts
@@ -58,15 +58,28 @@ export async function lookupIntrodbMarkers(
 ): Promise<IntrodbMarkers | null> {
   const doFetch = getFetcher();
   const url = `${INTRODB_BASE}/segments?imdb_id=${encodeURIComponent(imdbId)}&season=${season}&episode=${episode}`;
+  console.info("[introdb] GET", url);
   try {
     const res = await doFetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
-    if (!res.ok) return null;
+    if (!res.ok) {
+      console.info("[introdb] non-ok response", { url, status: res.status });
+      return null;
+    }
     const data = await res.json() as ApiResponse;
+    console.info("[introdb] raw response", {
+      imdb_id: data.imdb_id, intro: data.intro, outro: data.outro, recap: data.recap,
+    });
     const intro = normalizeSegment(data.intro);
     const outro = normalizeSegment(data.outro);
-    if (!intro && !outro) return null;
+    if (!intro && !outro) {
+      console.info("[introdb] both segments rejected by floor/shape", {
+        introRaw: data.intro, outroRaw: data.outro, floor: SUBMISSION_FLOOR,
+      });
+      return null;
+    }
     return { intro, outro, imdbId };
-  } catch {
+  } catch (err) {
+    console.info("[introdb] fetch threw", { url, error: (err as Error).message });
     return null;
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -265,6 +265,11 @@ export interface BingeDiagnostics {
         seasonSpecific: boolean;
       } | null;
     } | null;
+    introdb: {
+      imdbId: string;
+      intro: { start: number; end: number; confidence: number; submissionCount: number } | null;
+      outro: { start: number; end: number; confidence: number; submissionCount: number } | null;
+    } | null;
     learnedOutro: { sampleCount: number; offset: number } | null;
   };
   prefetch: {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -197,10 +197,12 @@ export type MarkerSource =
   | "chapter markers"
   | "AniSkip · duration OK"
   | "AniSkip · duration mismatch"
+  | "IntroDB · ok"
   | "learned outro offset"
   | "no signal — advance on EOF"
   | "no chapter data"
   | "no AniSkip data"
+  | "no IntroDB data"
   | "bridge missing chapter support";
 
 export interface BingeCapabilities {

--- a/routes/media.ts
+++ b/routes/media.ts
@@ -507,7 +507,7 @@ export default function mediaRoutes(app: Express, ctx: ServerContext): void {
 
     const [anime, introdb] = await Promise.all([
       tmdbId ? isAnime(tmdbId).catch(() => false) : Promise.resolve(false),
-      imdbId ? lookupIntrodbMarkers(imdbId, seasonNum, ep).catch((err) => {
+      imdbId ? lookupIntrodbMarkers(imdbId, seasonNum, ep, log).catch((err) => {
         log("warn", "IntroDB lookup threw", { error: (err as Error).message });
         return null;
       }) : Promise.resolve(null),

--- a/routes/media.ts
+++ b/routes/media.ts
@@ -499,10 +499,23 @@ export default function mediaRoutes(app: Express, ctx: ServerContext): void {
       return res.status(400).json({ error: "episode, duration, and season must be numbers" });
     }
 
+    log("info", "episode-markers request", {
+      title, season: seasonNum, episode: ep, duration: dur,
+      tmdbId: tmdbId ?? null, imdbId: imdbId ?? null,
+      willCallAniskipGate: !!tmdbId, willCallIntrodb: !!imdbId,
+    });
+
     const [anime, introdb] = await Promise.all([
       tmdbId ? isAnime(tmdbId).catch(() => false) : Promise.resolve(false),
-      imdbId ? lookupIntrodbMarkers(imdbId, seasonNum, ep).catch(() => null) : Promise.resolve(null),
+      imdbId ? lookupIntrodbMarkers(imdbId, seasonNum, ep).catch((err) => {
+        log("warn", "IntroDB lookup threw", { error: (err as Error).message });
+        return null;
+      }) : Promise.resolve(null),
     ]);
+
+    log("info", "episode-markers gates", {
+      anime, introdbNull: introdb === null, imdbProvided: !!imdbId,
+    });
 
     let aniskip = null;
     if (anime) {
@@ -525,11 +538,13 @@ export default function mediaRoutes(app: Express, ctx: ServerContext): void {
     }
 
     if (introdb) {
-      log("info", "IntroDB lookup", {
+      log("info", "IntroDB lookup: hit", {
         imdbId: introdb.imdbId, season: seasonNum, episode: ep,
         intro: introdb.intro ? `${introdb.intro.startSec}-${introdb.intro.endSec} (n=${introdb.intro.submissionCount})` : null,
         outro: introdb.outro ? `${introdb.outro.startSec} (n=${introdb.outro.submissionCount})` : null,
       });
+    } else if (imdbId) {
+      log("info", "IntroDB lookup: no usable segments", { imdbId, season: seasonNum, episode: ep });
     }
 
     res.json({ aniskip, introdb });

--- a/routes/media.ts
+++ b/routes/media.ts
@@ -8,6 +8,8 @@ import { getFileOffset } from "../lib/torrent/torrent-compat.js";
 import { hasPiece } from "../lib/torrent/torrent-compat.js";
 import { VIDEO_EXTENSIONS, SUBTITLE_EXTENSIONS, srtToVtt } from "../lib/media/media-utils.js";
 import { detectIntro, lookupExternal, lookupAniskipMarkers } from "../lib/media/intro-detect.js";
+import { lookupIntrodbMarkers } from "../lib/media/introdb.js";
+import { isAnime } from "../lib/media/anime-detect.js";
 import type { ServerContext, Torrent } from "../lib/types.js";
 import { getActiveDebridUrl, getActiveDebridFiles, getDebridFileUrl } from "../lib/torrent/debrid.js";
 
@@ -480,10 +482,13 @@ export default function mediaRoutes(app: Express, ctx: ServerContext): void {
     }
   });
 
-  // Binge mode: fetch both OP and ED markers from AniSkip for capability computation.
-  // Returns null when AniSkip has no coverage or title can't be resolved.
-  app.get("/api/aniskip-markers", async (req: Request, res: Response) => {
-    const { title, episode, duration, season } = req.query as { title?: string; episode?: string; duration?: string; season?: string };
+  // Binge mode: fetch OP/ED markers from AniSkip (anime only, via anime-gate) and/or
+  // IntroDB (IMDb-keyed). Returns null for each source when data is unavailable.
+  app.get("/api/episode-markers", async (req: Request, res: Response) => {
+    const { title, episode, duration, season, tmdbId, imdbId } = req.query as {
+      title?: string; episode?: string; duration?: string; season?: string;
+      tmdbId?: string; imdbId?: string;
+    };
     if (!title || !episode || !duration) {
       return res.status(400).json({ error: "title, episode, duration required" });
     }
@@ -493,26 +498,41 @@ export default function mediaRoutes(app: Express, ctx: ServerContext): void {
     if (!Number.isFinite(ep) || !Number.isFinite(dur) || !Number.isFinite(seasonNum)) {
       return res.status(400).json({ error: "episode, duration, and season must be numbers" });
     }
-    try {
-      const markers = await lookupAniskipMarkers(title, ep, dur, seasonNum);
-      if (markers) {
-        log("info", "AniSkip lookup", {
-          title, season: seasonNum, episode: ep,
-          malId: markers.resolution.malId,
-          jikanTitle: markers.resolution.jikanTitle,
-          jikanQuery: markers.resolution.jikanQuery,
-          seasonSpecific: markers.resolution.seasonSpecific,
-          op: `${markers.opStart}-${markers.opEnd}`,
-          ed: markers.edStart,
-        });
-      } else {
-        log("info", "AniSkip lookup: no markers", { title, season: seasonNum, episode: ep });
+
+    const [anime, introdb] = await Promise.all([
+      tmdbId ? isAnime(tmdbId).catch(() => false) : Promise.resolve(false),
+      imdbId ? lookupIntrodbMarkers(imdbId, seasonNum, ep).catch(() => null) : Promise.resolve(null),
+    ]);
+
+    let aniskip = null;
+    if (anime) {
+      try {
+        aniskip = await lookupAniskipMarkers(title, ep, dur, seasonNum);
+        if (aniskip) {
+          log("info", "AniSkip lookup", {
+            title, season: seasonNum, episode: ep,
+            malId: aniskip.resolution.malId,
+            jikanTitle: aniskip.resolution.jikanTitle,
+            op: `${aniskip.opStart}-${aniskip.opEnd}`,
+            ed: aniskip.edStart,
+          });
+        } else {
+          log("info", "AniSkip lookup: no markers", { title, season: seasonNum, episode: ep });
+        }
+      } catch (err) {
+        log("warn", "AniSkip markers lookup failed", { error: (err as Error).message });
       }
-      res.json({ markers });
-    } catch (err) {
-      log("warn", "AniSkip markers lookup failed", { error: (err as Error).message });
-      res.json({ markers: null });
     }
+
+    if (introdb) {
+      log("info", "IntroDB lookup", {
+        imdbId: introdb.imdbId, season: seasonNum, episode: ep,
+        intro: introdb.intro ? `${introdb.intro.startSec}-${introdb.intro.endSec} (n=${introdb.intro.submissionCount})` : null,
+        outro: introdb.outro ? `${introdb.outro.startSec} (n=${introdb.outro.submissionCount})` : null,
+      });
+    }
+
+    res.json({ aniskip, introdb });
   });
 
   // Extract an embedded subtitle stream as WebVTT

--- a/routes/rc.ts
+++ b/routes/rc.ts
@@ -232,6 +232,10 @@ export default function rcRoutes(app: Express, ctx: ServerContext): void {
       if (s.playerClient) sseWrite(s.playerClient, "remote-connected", { count: s.remoteClients.length });
     }
 
+    // Replay current binge-mode state so a reconnecting client doesn't
+    // fall back to the default "disabled" until the next broadcast.
+    sseWrite(resAsClient, "binge", s.bingeMode);
+
     // Heartbeat every 30s
     const heartbeat = setInterval(() => {
       try { res.write(": heartbeat\n\n"); } catch { clearInterval(heartbeat); }

--- a/src/lib/BingeCoordinator.ts
+++ b/src/lib/BingeCoordinator.ts
@@ -142,6 +142,13 @@ export class BingeCoordinator {
     const m = this.deps.getMarkers();
     if (m.outroStart !== null && t >= m.outroStart) {
       this.enterAdvancing();
+      return;
+    }
+    // EOF fallback: some containers report a duration slightly past the real stream end
+    // (e.g. 46:01 reported vs 46:00 actual), so mpv never emits eofReached. When we have
+    // no outro marker, treat "within 1s of reported duration" as EOF.
+    if (m.outroStart === null && this.duration > 0 && t >= this.duration - 1) {
+      this.enterAdvancing();
     }
   }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -475,21 +475,46 @@ export interface AniskipMarkersResult {
   resolution: AniskipResolution;
 }
 
-export async function fetchAniskipMarkers(
-  title: string,
-  episode: number,
-  durationSec: number,
-  season?: number,
-): Promise<AniskipMarkersResult | null> {
-  const seasonParam = season != null ? `&season=${season}` : "";
-  const url = `/api/aniskip-markers?title=${encodeURIComponent(title)}&episode=${episode}&duration=${Math.round(durationSec)}${seasonParam}`;
+export interface IntrodbSegmentResult {
+  startSec: number;
+  endSec: number;
+  confidence: number;
+  submissionCount: number;
+}
+
+export interface IntrodbMarkersResult {
+  intro: IntrodbSegmentResult | null;
+  outro: IntrodbSegmentResult | null;
+  imdbId: string;
+}
+
+export interface EpisodeMarkersResult {
+  aniskip: AniskipMarkersResult | null;
+  introdb: IntrodbMarkersResult | null;
+}
+
+export async function fetchEpisodeMarkers(args: {
+  title: string;
+  episode: number;
+  durationSec: number;
+  season?: number;
+  tmdbId?: string;
+  imdbId?: string;
+}): Promise<EpisodeMarkersResult> {
+  const params = new URLSearchParams({
+    title: args.title,
+    episode: String(args.episode),
+    duration: String(Math.round(args.durationSec)),
+  });
+  if (args.season != null) params.set("season", String(args.season));
+  if (args.tmdbId) params.set("tmdbId", args.tmdbId);
+  if (args.imdbId) params.set("imdbId", args.imdbId);
   try {
-    const res = await fetch(url);
-    if (!res.ok) return null;
-    const data = await res.json() as { markers: AniskipMarkersResult | null };
-    return data.markers;
+    const res = await fetch(`/api/episode-markers?${params.toString()}`);
+    if (!res.ok) return { aniskip: null, introdb: null };
+    return await res.json() as EpisodeMarkersResult;
   } catch {
-    return null;
+    return { aniskip: null, introdb: null };
   }
 }
 

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -34,7 +34,7 @@ import { useAudioTracks } from "../lib/useAudioTracks";
 import { useSeek } from "../lib/useSeek";
 import { useIntro } from "../lib/useIntro";
 import { formatBytes } from "../lib/utils";
-import { playTorrent, fetchLivePeers, fetchLanIp, searchStreams, autoPlay, fetchSeason, fetchEpisodeGroups, reportWatchProgress, postLearnOffset, getLearnedOffset, setBingeCapabilities, setBingeDiagnostics, setPersistedTracks, fetchAudioTracks, fetchSubtitleTracks, fetchAniskipMarkers, fetchPrefetchReady, fetchSeriesProgress } from "../lib/api";
+import { playTorrent, fetchLivePeers, fetchLanIp, searchStreams, autoPlay, fetchSeason, fetchEpisodeGroups, reportWatchProgress, postLearnOffset, getLearnedOffset, setBingeCapabilities, setBingeDiagnostics, setPersistedTracks, fetchAudioTracks, fetchSubtitleTracks, fetchEpisodeMarkers, fetchPrefetchReady, fetchSeriesProgress } from "../lib/api";
 import { BingeCoordinator, type CoordinatorState } from "../lib/BingeCoordinator";
 import { nextEpisodeFrom } from "../../lib/media/next-episode";
 import { startPrefetch as libStartPrefetch } from "../../lib/torrent/prefetch";
@@ -251,7 +251,7 @@ export default function Player() {
     state: "idle",
     duration: 0,
     markers: null,
-    signals: { chapters: null, aniskip: null, learnedOutro: null },
+    signals: { chapters: null, aniskip: null, introdb: null, learnedOutro: null },
     prefetch: { threshold: 0.9, firedAtTime: null, firedAtEpoch: null, resolved: null, ready: false },
     nextAction: null,
     events: [],
@@ -619,17 +619,36 @@ export default function Player() {
         const showTitle = state?.baseName || state?.title || mediaTitle;
         const epNum = state?.episode != null ? Number(state.episode) : null;
         const seasonNum = state?.season != null ? Number(state.season) : 1;
-        const [chapters, learned, aniskip] = await Promise.all([
+        const [chapters, learned, episodeMarkers] = await Promise.all([
           mpvGetChapters().catch(() => []),
           tmdbId ? getLearnedOffset(tmdbId).catch(() => null) : Promise.resolve(null),
           showTitle && epNum && Number.isFinite(epNum)
-            ? fetchAniskipMarkers(showTitle, epNum, duration, seasonNum).catch(() => null)
-            : Promise.resolve(null),
+            ? fetchEpisodeMarkers({
+                title: showTitle,
+                episode: epNum,
+                durationSec: duration,
+                season: seasonNum,
+                tmdbId: state?.tmdbId != null ? String(state.tmdbId) : undefined,
+                imdbId: state?.imdbId ?? undefined,
+              }).catch(() => ({ aniskip: null, introdb: null }))
+            : Promise.resolve({ aniskip: null, introdb: null }),
         ]);
+        const aniskip = episodeMarkers.aniskip;
+        const introdb = episodeMarkers.introdb;
         const markers = computeMarkers({
           bridgeHasChapterSupport: bridgeHasChapterSupport(),
           chapters,
-          aniskip,
+          aniskip: aniskip ? {
+            opStart: aniskip.opStart, opEnd: aniskip.opEnd,
+            edStart: aniskip.edStart, episodeLength: aniskip.episodeLength,
+          } : null,
+          introdb: introdb ? {
+            introStart: introdb.intro?.startSec ?? null,
+            introEnd: introdb.intro?.endSec ?? null,
+            outroStart: introdb.outro?.startSec ?? null,
+            introSubmissionCount: introdb.intro?.submissionCount ?? 0,
+            outroSubmissionCount: introdb.outro?.submissionCount ?? 0,
+          } : null,
           learnedOutroOffset: learned && learned.outro_offset !== null
             ? { offset: learned.outro_offset, sampleCount: learned.sample_count }
             : null,
@@ -679,6 +698,17 @@ export default function Player() {
             ed: aniskip.edStart > 0 ? { start: aniskip.edStart, end: duration } : null,
             durationMatch: Math.abs(aniskip.episodeLength - duration) <= 30,
             resolution: aniskip.resolution ?? null,
+          } : null,
+          introdb: introdb ? {
+            imdbId: introdb.imdbId,
+            intro: introdb.intro ? {
+              start: introdb.intro.startSec, end: introdb.intro.endSec,
+              confidence: introdb.intro.confidence, submissionCount: introdb.intro.submissionCount,
+            } : null,
+            outro: introdb.outro ? {
+              start: introdb.outro.startSec, end: introdb.outro.endSec,
+              confidence: introdb.outro.confidence, submissionCount: introdb.outro.submissionCount,
+            } : null,
           } : null,
           learnedOutro: learned && learned.outro_offset !== null
             ? { sampleCount: learned.sample_count, offset: learned.outro_offset }

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -425,27 +425,28 @@ export default function Player() {
 
   // Raw ffprobe tracks for pickAudio/pickSubtitle — cached per episode so the
   // commandRef handlers can look up {lang, title} when persisting user picks.
+  // State (not ref) so the picker effects below re-run when fetches complete.
   interface RawAudioTrack { streamIndex: number; lang: string | null; title: string | null; channels?: number }
   interface RawSubtitleTrack { streamIndex: number; lang: string | null; title: string | null }
-  const rawAudioTracksRef = useRef<RawAudioTrack[]>([]);
-  const rawSubtitleTracksRef = useRef<RawSubtitleTrack[]>([]);
+  const [rawAudioTracks, setRawAudioTracks] = useState<RawAudioTrack[]>([]);
+  const [rawSubtitleTracks, setRawSubtitleTracks] = useState<RawSubtitleTrack[]>([]);
   const appliedPersistedAudio = useRef(false);
   const appliedPersistedSub = useRef(false);
 
   useEffect(() => {
     if (!infoHash || !fileIndex) return;
     let cancelled = false;
-    rawAudioTracksRef.current = [];
-    rawSubtitleTracksRef.current = [];
+    setRawAudioTracks([]);
+    setRawSubtitleTracks([]);
     appliedPersistedAudio.current = false;
     appliedPersistedSub.current = false;
     fetchAudioTracks(infoHash, fileIndex).then((data) => {
       if (cancelled) return;
-      rawAudioTracksRef.current = data.tracks ?? [];
+      setRawAudioTracks(data.tracks ?? []);
     }).catch(() => {});
     fetchSubtitleTracks(infoHash, fileIndex).then((data) => {
       if (cancelled) return;
-      rawSubtitleTracksRef.current = data.tracks ?? [];
+      setRawSubtitleTracks(data.tracks ?? []);
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [infoHash, fileIndex]);
@@ -453,36 +454,34 @@ export default function Player() {
   useEffect(() => {
     if (appliedPersistedAudio.current) return;
     if (!persistedTracks.audio) return;
-    const raw = rawAudioTracksRef.current;
-    if (raw.length === 0) return;
+    if (rawAudioTracks.length === 0) return;
     const idx = pickAudioTrack(
-      raw.map((t, i) => ({ index: i, lang: t.lang ?? "", title: t.title ?? undefined, channels: t.channels })),
+      rawAudioTracks.map((t, i) => ({ index: i, lang: t.lang ?? "", title: t.title ?? undefined, channels: t.channels })),
       persistedTracks.audio,
       "en",
     );
     if (idx >= 0) {
       mpvSetAudioTrack(idx);
-      activeAudioRef.current = raw[idx].streamIndex;
+      activeAudioRef.current = rawAudioTracks[idx].streamIndex;
       appliedPersistedAudio.current = true;
     }
-  }, [persistedTracks.audio, activeAudioRef, audioTracks]);
+  }, [persistedTracks.audio, activeAudioRef, rawAudioTracks]);
 
   useEffect(() => {
     if (appliedPersistedSub.current) return;
     if (!persistedTracks.subtitles) return;
-    const raw = rawSubtitleTracksRef.current;
-    if (raw.length === 0) return;
+    if (rawSubtitleTracks.length === 0) return;
     const idx = pickSubtitleTrack(
-      raw.map((t, i) => ({ index: i, lang: t.lang ?? "", title: t.title ?? undefined })),
+      rawSubtitleTracks.map((t, i) => ({ index: i, lang: t.lang ?? "", title: t.title ?? undefined })),
       persistedTracks.subtitles,
       "en",
     );
     if (idx >= 0) {
       mpvSetSubtitleTrack(idx);
-      activeSubRef.current = `embedded:${raw[idx].streamIndex}`;
+      activeSubRef.current = `embedded:${rawSubtitleTracks[idx].streamIndex}`;
       appliedPersistedSub.current = true;
     }
-  }, [persistedTracks.subtitles, activeSubRef, subs]);
+  }, [persistedTracks.subtitles, activeSubRef, rawSubtitleTracks]);
 
   // ── Next episode (triggered by phone remote) ──
   const handleNextEpisode = useCallback(async (nextSeason: number, nextEpisode: number) => {
@@ -892,7 +891,7 @@ export default function Player() {
           mpvSetSubtitleTrack(idx);
           if (rcSessionId && sub.value.startsWith("embedded:")) {
             const streamIdx = parseInt(sub.value.slice("embedded:".length), 10);
-            const raw = rawSubtitleTracksRef.current.find(t => t.streamIndex === streamIdx);
+            const raw = rawSubtitleTracks.find(t => t.streamIndex === streamIdx);
             if (raw?.lang) {
               void setPersistedTracks(rcSessionId, rcAuthToken, {
                 audio: persistedTracks.audio,
@@ -909,7 +908,7 @@ export default function Player() {
         const streamIdx = typeof streamIndex === "string" ? parseInt(streamIndex, 10) : streamIndex;
         activeAudioRef.current = streamIdx;
         if (rcSessionId) {
-          const raw = rawAudioTracksRef.current.find(t => t.streamIndex === streamIdx);
+          const raw = rawAudioTracks.find(t => t.streamIndex === streamIdx);
           if (raw?.lang) {
             void setPersistedTracks(rcSessionId, rcAuthToken, {
               audio: { lang: raw.lang, title: raw.title ?? "" },

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -619,6 +619,11 @@ export default function Player() {
         const showTitle = state?.baseName || state?.title || mediaTitle;
         const epNum = state?.episode != null ? Number(state.episode) : null;
         const seasonNum = state?.season != null ? Number(state.season) : 1;
+        console.info("[binge-markers] inputs", {
+          showTitle, seasonNum, epNum, duration,
+          tmdbId, imdbId: state?.imdbId ?? null,
+          bridgeHasChapterSupport: bridgeHasChapterSupport(),
+        });
         const [chapters, learned, episodeMarkers] = await Promise.all([
           mpvGetChapters().catch(() => []),
           tmdbId ? getLearnedOffset(tmdbId).catch(() => null) : Promise.resolve(null),
@@ -635,6 +640,13 @@ export default function Player() {
         ]);
         const aniskip = episodeMarkers.aniskip;
         const introdb = episodeMarkers.introdb;
+        console.info("[binge-markers] fetched", {
+          chapterCount: Array.isArray(chapters) ? chapters.length : null,
+          hasLearned: !!learned && learned.outro_offset !== null,
+          aniskipPresent: !!aniskip,
+          introdbPresent: !!introdb,
+          introdbPayload: introdb,
+        });
         const markers = computeMarkers({
           bridgeHasChapterSupport: bridgeHasChapterSupport(),
           chapters,
@@ -653,6 +665,10 @@ export default function Player() {
             ? { offset: learned.outro_offset, sampleCount: learned.sample_count }
             : null,
           fileDuration: duration,
+        });
+        console.info("[binge-markers] computed", {
+          introStart: markers.introStart, introEnd: markers.introEnd, introSource: markers.introSource,
+          outroStart: markers.outroStart, outroSource: markers.outroSource,
         });
         currentMarkersRef.current = markers;
         const prefetchVia = modeRef.current === "debrid" ? "debrid cache" : "torrent pieces";

--- a/src/pages/Remote.css
+++ b/src/pages/Remote.css
@@ -805,6 +805,18 @@
   cursor: not-allowed;
 }
 
+.remote-binge-beta {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: var(--accent);
+  color: var(--bg-deep);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  vertical-align: middle;
+}
+
 .remote-binge-panel {
   margin-top: 8px;
   padding: 10px 12px;
@@ -1201,4 +1213,301 @@
   height: 100%;
   background: var(--accent-bright);
   border-radius: 0 1px 1px 0;
+}
+
+/* ── Grouped control sections ── */
+.remote-section {
+  width: 100%;
+  max-width: 400px;
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius);
+  padding: 10px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.remote-section-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.remote-control-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.remote-control-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 500;
+  min-width: 48px;
+  flex-shrink: 0;
+}
+
+.remote-control-row .remote-volume-slider {
+  flex: 1;
+  min-width: 0;
+}
+
+.remote-control-row .remote-sub-select {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  font-size: 12px;
+}
+
+.remote-volume-value {
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  min-width: 36px;
+  text-align: right;
+}
+
+/* ── Stepper (size / delay) ── */
+.remote-sub-controls-row {
+  display: flex;
+  gap: 10px;
+}
+
+.remote-sub-control {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.remote-sub-control-label {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.remote-stepper {
+  display: flex;
+  align-items: stretch;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.remote-stepper button {
+  flex-shrink: 0;
+  padding: 8px 10px;
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+.remote-stepper button:active:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.remote-stepper button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.remote-stepper-value {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.remote-stepper-value.active {
+  color: var(--accent-bright);
+}
+
+/* ── Content row: compact grouped buttons ── */
+.remote-content-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.remote-content-btn {
+  flex: 1 1 0;
+  min-width: 0;
+  padding: 10px 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  transition: background var(--transition), border-color var(--transition), transform var(--transition);
+  cursor: pointer;
+}
+
+.remote-content-btn:active:not(:disabled) {
+  transform: scale(0.97);
+  background: var(--bg-hover);
+}
+
+.remote-content-btn.active {
+  border-color: var(--accent);
+  background: rgba(201, 168, 76, 0.08);
+}
+
+.remote-content-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.remote-content-btn-label {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.remote-content-btn-meta {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
+/* ── Binge header with switch ── */
+.remote-binge-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.remote-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  position: relative;
+  flex-shrink: 0;
+  cursor: pointer;
+  padding: 0;
+  transition: background var(--transition), border-color var(--transition);
+}
+
+.remote-switch::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  transition: left var(--transition), background var(--transition);
+}
+
+.remote-switch.on {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.remote-switch.on::after {
+  left: 22px;
+  background: var(--bg-deep);
+}
+
+.remote-switch:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ── Binge features collapsible ── */
+.remote-binge-features-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 8px 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+.remote-binge-features-toggle:active {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.remote-binge-features-count {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.remote-binge-feature {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-primary);
+}
+
+.remote-binge-feature-mark {
+  flex-shrink: 0;
+  width: 14px;
+  text-align: center;
+  color: var(--text-muted);
+  font-weight: 700;
+}
+
+.remote-binge-feature-mark.on {
+  color: var(--green);
+}
+
+.remote-binge-feature-label {
+  flex-shrink: 0;
+}
+
+/* Override inherited binge-panel padding so it fits inside a section */
+.remote-section .remote-binge-panel {
+  margin-top: 0;
+  padding: 10px 12px;
+}
+
+.remote-section .remote-binge-help {
+  margin-top: 0;
+  padding: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
 }

--- a/src/pages/Remote.css
+++ b/src/pages/Remote.css
@@ -1,4 +1,11 @@
 .remote-page {
+  /* Scoped contrast bump: remote surfaces sit on near-black with faint
+     translucent panels, so the default muted/secondary tones read as
+     gray-on-gray. These overrides raise every label and hint above 7:1
+     without touching the global tokens used elsewhere. */
+  --text-muted: #a8a1b3;
+  --text-secondary: #c6bfd1;
+
   min-height: 100vh;
   min-height: 100dvh;
   background: var(--bg-deep);
@@ -451,7 +458,6 @@
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
-  opacity: 0.7;
 }
 
 .remote-torrent-info span {
@@ -807,14 +813,16 @@
 
 .remote-binge-beta {
   display: inline-block;
-  padding: 2px 6px;
+  padding: 2px 7px;
   border-radius: 3px;
-  background: var(--accent);
+  background: var(--accent-bright);
   color: var(--bg-deep);
-  font-size: 9px;
+  font-size: 10px;
   font-weight: 800;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
+  line-height: 1.2;
   vertical-align: middle;
+  box-shadow: 0 0 0 1px rgba(226, 192, 109, 0.25);
 }
 
 .remote-binge-panel {

--- a/src/pages/Remote.tsx
+++ b/src/pages/Remote.tsx
@@ -974,7 +974,7 @@ export default function Remote() {
       )}
 
       {/* BINGE MODE */}
-      {sessionId && (
+      {sessionId && state?.mediaType === "tv" && (
         <section className="remote-section">
           <div className="remote-binge-header">
             <div className="remote-section-label">

--- a/src/pages/Remote.tsx
+++ b/src/pages/Remote.tsx
@@ -835,6 +835,7 @@ export default function Remote() {
             disabled={isDisabled}
           >
             {bingeMode.enabled ? "Binge mode: ON" : "Binge mode: off"}
+            <span className="remote-binge-beta">BETA</span>
           </button>
           {!bingeMode.enabled && (
             <div className="remote-binge-help">
@@ -938,6 +939,23 @@ export default function Remote() {
                                   <span style={{ fontStyle: "italic" }}>"{d.signals.aniskip.resolution.jikanQuery}"</span>
                                   {!d.signals.aniskip.resolution.seasonSpecific && " · ⚠ season-ambiguous (fell back to base title)"}
                                 </div>
+                              )}
+                            </>
+                          : <span className="remote-binge-source">none</span>}
+                      </div>
+                      <div>
+                        IntroDB:{" "}
+                        {d.signals.introdb
+                          ? <>
+                              <span className="remote-binge-source">imdb {d.signals.introdb.imdbId}</span>
+                              {d.signals.introdb.intro && (
+                                <div>intro {fmtSec(d.signals.introdb.intro.start)}–{fmtSec(d.signals.introdb.intro.end)} (n={d.signals.introdb.intro.submissionCount}, c={d.signals.introdb.intro.confidence.toFixed(2)})</div>
+                              )}
+                              {d.signals.introdb.outro && (
+                                <div>outro {fmtSec(d.signals.introdb.outro.start)}–{fmtSec(d.signals.introdb.outro.end)} (n={d.signals.introdb.outro.submissionCount}, c={d.signals.introdb.outro.confidence.toFixed(2)})</div>
+                              )}
+                              {!d.signals.introdb.intro && !d.signals.introdb.outro && (
+                                <span className="remote-binge-source"> · no segments passed floor</span>
                               )}
                             </>
                           : <span className="remote-binge-source">none</span>}

--- a/src/pages/Remote.tsx
+++ b/src/pages/Remote.tsx
@@ -104,7 +104,15 @@ export default function Remote() {
   const [bingeMode, setBingeModeState] = useState<{ enabled: boolean; capabilities: BingeCapabilities | null; diagnostics: BingeDiagnostics | null }>({ enabled: false, capabilities: null, diagnostics: null });
   const [bingeFlash, setBingeFlash] = useState<string | null>(null);
   const [showBingeDebug, setShowBingeDebug] = useState(false);
+  const [showBingeFeatures, setShowBingeFeatures] = useState(false);
   const bingeToastedRef = useRef(false);
+
+  // Dev-mode flag hides binge diagnostics panel unless explicitly requested
+  const devMode = (() => {
+    if (typeof window === "undefined") return false;
+    if (searchParams.get("dev") === "1") return true;
+    try { return window.localStorage.getItem("rattin.remoteDev") === "1"; } catch { return false; }
+  })();
 
   useEffect(() => {
     if (!bingeMode.enabled) { bingeToastedRef.current = false; setBingeFlash(null); return; }
@@ -729,9 +737,12 @@ export default function Remote() {
         <span className="remote-time">{formatTime(dur)}</span>
       </div>
 
-      <div className="remote-split-row">
-        <div className="remote-volume-row">
-          <svg viewBox="0 0 24 24" width="18" height="18" fill="var(--text-secondary)">
+      {/* AUDIO */}
+      <section className="remote-section">
+        <div className="remote-section-label">Audio</div>
+        <div className="remote-control-row">
+          <span className="remote-control-label">Volume</span>
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="var(--text-muted)" aria-hidden="true">
             <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
           </svg>
           <input
@@ -741,130 +752,287 @@ export default function Remote() {
             value={displayVolume}
             onChange={handleVolumeChange}
             disabled={isDisabled}
+            aria-label="Volume"
           />
+          <span className="remote-volume-value">{Math.round(displayVolume * 100)}%</span>
         </div>
-        {state?.subs?.length > 0 && (
-          <select
-            className="remote-sub-select"
-            value={state.activeSub || ""}
-            onChange={(e) => sendCommand("subtitle", e.target.value)}
-            disabled={isDisabled}
-          >
-            <option value="">Subs Off</option>
-            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-            {state.subs.map((s: any) => (
-              <option key={s.value} value={s.value}>{s.label}</option>
-            ))}
-          </select>
-        )}
-      </div>
-
-      {state?.subs?.length > 0 && (
-        <div className="remote-split-row">
-          <div className="remote-sub-size">
-            <button className="remote-sub-size-btn" onClick={() => sendCommand("sub-size", -5)} disabled={isDisabled}>A−</button>
-            <span className="remote-sub-size-val">{state.subSize ?? 55}</span>
-            <button className="remote-sub-size-btn" onClick={() => sendCommand("sub-size", 5)} disabled={isDisabled}>A+</button>
-          </div>
-          <div className="remote-sub-size">
-            <button className="remote-sub-size-btn" onClick={() => sendCommand("sub-delay", -0.1)} disabled={isDisabled}>−0.1s</button>
-            <span className={`remote-sub-size-val${(state.subDelay ?? 0) !== 0 ? " active" : ""}`}>{(state.subDelay ?? 0).toFixed(1)}s</span>
-            <button className="remote-sub-size-btn" onClick={() => sendCommand("sub-delay", 0.1)} disabled={isDisabled}>+0.1s</button>
-          </div>
-        </div>
-      )}
-
-      {state?.audioTracks?.length > 1 && (
-        <div className="remote-sub-row">
-          <select
-            className="remote-sub-select"
-            value={state.activeAudio ?? ""}
-            onChange={(e) => sendCommand("audio", parseInt(e.target.value, 10))}
-            disabled={isDisabled}
-          >
-            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-            {state.audioTracks.map((t: any) => (
-              <option key={t.value} value={t.value}>{t.label}</option>
-            ))}
-          </select>
-        </div>
-      )}
-
-      <div className="remote-split-row">
-        {state?.sources?.length > 1 && (
-          <button
-            className="remote-source-toggle"
-            onClick={() => { setShowSources((v) => !v); setShowEpisodes(false); }}
-            disabled={isDisabled}
-          >
-            <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
-              <path d="M4 6h16v2H4zm0 5h16v2H4zm0 5h16v2H4z" />
-            </svg>
-            Sources ({state.sources.length})
-          </button>
-        )}
-        {state?.mediaType === "tv" && state?.season > 0 && state?.episode > 0 && (() => {
-          const next = nextEpisodeFrom({
-            season: state.season,
-            episode: state.episode,
-            seasonEpisodeCount: state.seasonEpisodeCount || undefined,
-            seasonCount: state.seasonCount || undefined,
-          });
-          if (!next) return null;
-          return (
-            <button
-              className="remote-next-episode"
-              onClick={() => sendCommand("next-episode", { season: next.season, episode: next.episode })}
+        {state?.audioTracks?.length > 1 && (
+          <div className="remote-control-row">
+            <span className="remote-control-label">Track</span>
+            <select
+              className="remote-sub-select"
+              value={state.activeAudio ?? ""}
+              onChange={(e) => sendCommand("audio", parseInt(e.target.value, 10))}
               disabled={isDisabled}
+              aria-label="Audio track"
             >
-              Next Ep
-              <span className="remote-next-episode-label">S{next.season}E{next.episode}</span>
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
-                <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
-              </svg>
-            </button>
-          );
-        })()}
-      </div>
+              {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+              {state.audioTracks.map((t: any) => (
+                <option key={t.value} value={t.value}>{t.label}</option>
+              ))}
+            </select>
+          </div>
+        )}
+      </section>
 
-      {sessionId && (
-        <>
-          <button
-            className={bingeMode.enabled ? "remote-binge-toggle on" : "remote-binge-toggle"}
-            onClick={() => setBingeMode(sessionId, !bingeMode.enabled)}
-            disabled={isDisabled}
-          >
-            {bingeMode.enabled ? "Binge mode: ON" : "Binge mode: off"}
-            <span className="remote-binge-beta">BETA</span>
-          </button>
-          {!bingeMode.enabled && (
-            <div className="remote-binge-help">
-              Auto-skip intros and credits, auto-advance to the next episode, and keep your audio/subtitle picks across episodes. Toggle off anytime to stop.
+      {/* SUBTITLES */}
+      {state?.subs?.length > 0 && (
+        <section className="remote-section">
+          <div className="remote-section-label">Subtitles</div>
+          <div className="remote-control-row">
+            <span className="remote-control-label">Track</span>
+            <select
+              className="remote-sub-select"
+              value={state.activeSub || ""}
+              onChange={(e) => sendCommand("subtitle", e.target.value)}
+              disabled={isDisabled}
+              aria-label="Subtitle track"
+            >
+              <option value="">Off</option>
+              {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+              {state.subs.map((s: any) => (
+                <option key={s.value} value={s.value}>{s.label}</option>
+              ))}
+            </select>
+          </div>
+          <div className="remote-sub-controls-row">
+            <div className="remote-sub-control">
+              <span className="remote-sub-control-label">Size</span>
+              <div className="remote-stepper">
+                <button onClick={() => sendCommand("sub-size", -5)} disabled={isDisabled} aria-label="Decrease subtitle size">A−</button>
+                <span className="remote-stepper-value">{state.subSize ?? 55}</span>
+                <button onClick={() => sendCommand("sub-size", 5)} disabled={isDisabled} aria-label="Increase subtitle size">A+</button>
+              </div>
             </div>
+            <div className="remote-sub-control">
+              <span className="remote-sub-control-label">Delay</span>
+              <div className="remote-stepper">
+                <button onClick={() => sendCommand("sub-delay", -0.1)} disabled={isDisabled} aria-label="Decrease subtitle delay">−0.1s</button>
+                <span className={`remote-stepper-value${(state.subDelay ?? 0) !== 0 ? " active" : ""}`}>{(state.subDelay ?? 0).toFixed(1)}s</span>
+                <button onClick={() => sendCommand("sub-delay", 0.1)} disabled={isDisabled} aria-label="Increase subtitle delay">+0.1s</button>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* CONTENT */}
+      {(() => {
+        const hasMultiSource = state?.sources?.length > 1;
+        const isTv = state?.mediaType === "tv" && state?.tmdbId;
+        const next = isTv && state?.season > 0 && state?.episode > 0
+          ? nextEpisodeFrom({
+              season: state.season,
+              episode: state.episode,
+              seasonEpisodeCount: state.seasonEpisodeCount || undefined,
+              seasonCount: state.seasonCount || undefined,
+            })
+          : null;
+        if (!hasMultiSource && !isTv) return null;
+        return (
+          <section className="remote-section">
+            <div className="remote-section-label">Content</div>
+            <div className="remote-content-row">
+              {isTv && (
+                <button
+                  className={`remote-content-btn${showEpisodes ? " active" : ""}`}
+                  onClick={() => { if (!showEpisodes) openEpisodeBrowser(); else setShowEpisodes(false); setShowSources(false); }}
+                  disabled={isDisabled}
+                >
+                  <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true">
+                    <path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z" />
+                  </svg>
+                  <span className="remote-content-btn-label">Episodes</span>
+                  {state.season > 0 && <span className="remote-content-btn-meta">S{state.season}E{state.episode}</span>}
+                </button>
+              )}
+              {next && (
+                <button
+                  className="remote-content-btn"
+                  onClick={() => sendCommand("next-episode", { season: next.season, episode: next.episode })}
+                  disabled={isDisabled}
+                >
+                  <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true">
+                    <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" />
+                  </svg>
+                  <span className="remote-content-btn-label">Next Ep</span>
+                  <span className="remote-content-btn-meta">S{next.season}E{next.episode}</span>
+                </button>
+              )}
+              {hasMultiSource && (
+                <button
+                  className={`remote-content-btn${showSources ? " active" : ""}`}
+                  onClick={() => { setShowSources((v) => !v); setShowEpisodes(false); }}
+                  disabled={isDisabled}
+                >
+                  <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true">
+                    <path d="M4 6h16v2H4zm0 5h16v2H4zm0 5h16v2H4z" />
+                  </svg>
+                  <span className="remote-content-btn-label">Sources</span>
+                  <span className="remote-content-btn-meta">{state.sources.length}</span>
+                </button>
+              )}
+            </div>
+          </section>
+        );
+      })()}
+
+      {showSources && state?.sources?.length > 1 && (
+        <div className="remote-sources-panel">
+          {state.sources.map((s: any) => {
+            const isCurrent = s.infoHash === state.infoHash;
+            return (
+              <button
+                key={s.infoHash}
+                className={`remote-source-item${isCurrent ? " active" : ""}`}
+                onClick={() => {
+                  if (!isCurrent) {
+                    sendCommand("switch-source", s);
+                    setShowSources(false);
+                  }
+                }}
+              >
+                <div className="remote-source-item-name">
+                  {s.name}
+                </div>
+                <div className="remote-source-item-meta">
+                  {isCurrent && <span className="remote-source-tag current">Playing</span>}
+                  {s.tags?.filter((t: string) => t !== "Native").map((t: string) => (
+                    <span key={t} className="remote-source-tag">{t}</span>
+                  ))}
+                  <span className="remote-source-seeds">
+                    <span className="remote-source-seed-dot" />
+                    {s.seeders ?? "?"}
+                  </span>
+                  {s.size > 0 && <span className="remote-source-size">{formatBytes(s.size)}</span>}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {showEpisodes && state?.mediaType === "tv" && (
+        <div className="remote-episodes-panel">
+          {(state.seasonCount > 1 || epBrowserSeason !== state.season) && (
+            <div className="remote-episodes-season-bar">
+              {Array.from({ length: state.seasonCount || 1 }, (_, i) => i + 1).map((s) => (
+                <button
+                  key={s}
+                  className={`remote-episodes-season-btn${s === epBrowserSeason ? " active" : ""}`}
+                  onClick={() => switchEpBrowserSeason(s)}
+                >
+                  S{s}
+                </button>
+              ))}
+            </div>
+          )}
+          <div className="remote-episodes-list">
+            {epBrowserEps === null ? (
+              <div className="remote-episodes-loading"><div className="remote-spinner" /></div>
+            ) : epBrowserEps.length === 0 ? (
+              <div className="remote-episodes-empty">No episodes found</div>
+            ) : (
+              epBrowserEps.map((ep: any) => {
+                const epKey = `s${epBrowserSeason}e${ep.episode_number}`;
+                const prog = epProgress.get(epKey);
+                const pct = prog && prog.duration > 0 ? Math.min(100, (prog.position / prog.duration) * 100) : 0;
+                const isCurrent = epBrowserSeason === state.season && ep.episode_number === state.episode;
+                return (
+                  <button
+                    key={ep.id}
+                    className={`remote-ep-item${isCurrent ? " current" : ""}${prog?.finished ? " watched" : ""}`}
+                    onClick={() => playEpisode(epBrowserSeason, ep.episode_number)}
+                    disabled={isDisabled || isCurrent}
+                  >
+                    <span className="remote-ep-num">E{ep.episode_number}</span>
+                    <div className="remote-ep-info">
+                      <span className="remote-ep-title">{ep.name}</span>
+                      {ep.runtime && <span className="remote-ep-runtime">{ep.runtime}m</span>}
+                    </div>
+                    {isCurrent && (
+                      <span className="remote-ep-playing">
+                        <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
+                      </span>
+                    )}
+                    {prog?.finished && !isCurrent && (
+                      <svg className="remote-ep-check" viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+                        <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+                      </svg>
+                    )}
+                    {pct > 0 && !prog?.finished && (
+                      <div className="remote-ep-progress">
+                        <div className="remote-ep-progress-fill" style={{ width: `${pct}%` }} />
+                      </div>
+                    )}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* BINGE MODE */}
+      {sessionId && (
+        <section className="remote-section">
+          <div className="remote-binge-header">
+            <div className="remote-section-label">
+              Binge Mode
+              <span className="remote-binge-beta">BETA</span>
+            </div>
+            <button
+              type="button"
+              className={`remote-switch${bingeMode.enabled ? " on" : ""}`}
+              onClick={() => setBingeMode(sessionId, !bingeMode.enabled)}
+              disabled={isDisabled}
+              role="switch"
+              aria-checked={bingeMode.enabled}
+              aria-label="Toggle binge mode"
+            />
+          </div>
+          {!bingeMode.enabled && (
+            <p className="remote-binge-help">
+              Auto-skip intros and credits, auto-advance to the next episode, and keep your audio/subtitle picks across episodes.
+            </p>
           )}
           {bingeFlash && <div className="remote-flash">{bingeFlash}</div>}
-          {bingeMode.enabled && bingeMode.capabilities && (
-            <div className="remote-binge-panel">
-              <div className="remote-binge-panel-header">
-                Binge mode: ON{state?.title ? ` — ${state.title}` : ""}
-                {state?.season && state?.episode ? ` S${state.season}E${state.episode}` : ""}
-              </div>
-              <div>{symbolFor(bingeMode.capabilities.autoSkipIntro.enabled)} Auto-skip intro <span className="remote-binge-source">{bingeMode.capabilities.autoSkipIntro.source}</span></div>
-              <div>
-                {symbolFor(bingeMode.capabilities.autoSkipCredits.enabled)} Auto-skip credits{" "}
-                <span className="remote-binge-source">
-                  {bingeMode.capabilities.autoSkipCredits.source}
-                  {bingeMode.capabilities.autoSkipCredits.sampleCount != null
-                    ? ` (${bingeMode.capabilities.autoSkipCredits.sampleCount} sample${bingeMode.capabilities.autoSkipCredits.sampleCount === 1 ? "" : "s"})`
-                    : ""}
-                </span>
-              </div>
-              <div>{symbolFor(bingeMode.capabilities.persistTracks.enabled)} Persist audio/subs</div>
-              <div>{symbolFor(bingeMode.capabilities.autoAdvance.enabled)} Auto-advance{bingeMode.capabilities.autoAdvance.viaEOF ? " on EOF" : ""}</div>
-              <div>{symbolFor(bingeMode.capabilities.prefetch.enabled)} Prefetch next episode <span className="remote-binge-source">{bingeMode.capabilities.prefetch.via ? `via ${bingeMode.capabilities.prefetch.via}` : ""}</span></div>
-            </div>
-          )}
-          {bingeMode.enabled && bingeMode.diagnostics && (
+          {bingeMode.enabled && bingeMode.capabilities && (() => {
+            const c = bingeMode.capabilities;
+            const features = [
+              { key: "intro", label: "Auto-skip intro", enabled: c.autoSkipIntro.enabled, source: c.autoSkipIntro.source },
+              { key: "credits", label: "Auto-skip credits", enabled: c.autoSkipCredits.enabled, source: `${c.autoSkipCredits.source}${c.autoSkipCredits.sampleCount != null ? ` (${c.autoSkipCredits.sampleCount} sample${c.autoSkipCredits.sampleCount === 1 ? "" : "s"})` : ""}` },
+              { key: "tracks", label: "Persist audio/subs", enabled: c.persistTracks.enabled, source: "" },
+              { key: "advance", label: `Auto-advance${c.autoAdvance.viaEOF ? " on EOF" : ""}`, enabled: c.autoAdvance.enabled, source: "" },
+              { key: "prefetch", label: "Prefetch next episode", enabled: c.prefetch.enabled, source: c.prefetch.via ? `via ${c.prefetch.via}` : "" },
+            ];
+            const activeCount = features.filter((f) => f.enabled).length;
+            return (
+              <>
+                <button
+                  type="button"
+                  className="remote-binge-features-toggle"
+                  onClick={() => setShowBingeFeatures((s) => !s)}
+                  aria-expanded={showBingeFeatures}
+                >
+                  <span>{showBingeFeatures ? "▾" : "▸"} Features</span>
+                  <span className="remote-binge-features-count">{activeCount} of {features.length} active</span>
+                </button>
+                {showBingeFeatures && (
+                  <div className="remote-binge-panel">
+                    {features.map((f) => (
+                      <div key={f.key} className="remote-binge-feature">
+                        <span className={`remote-binge-feature-mark${f.enabled ? " on" : ""}`}>{symbolFor(f.enabled)}</span>
+                        <span className="remote-binge-feature-label">{f.label}</span>
+                        {f.source && <span className="remote-binge-source">{f.source}</span>}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </>
+            );
+          })()}
+          {devMode && bingeMode.enabled && bingeMode.diagnostics && (
             <div className="remote-binge-debug">
               <button
                 className="remote-binge-debug-toggle"
@@ -996,117 +1164,7 @@ export default function Remote() {
               })()}
             </div>
           )}
-        </>
-      )}
-
-      {state?.mediaType === "tv" && state?.tmdbId && (
-        <button
-          className="remote-episodes-toggle"
-          onClick={() => { if (!showEpisodes) openEpisodeBrowser(); else setShowEpisodes(false); setShowSources(false); }}
-          disabled={isDisabled}
-        >
-          <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
-            <path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z"/>
-          </svg>
-          Episodes
-          {state.season > 0 && <span className="remote-episodes-current">S{state.season}E{state.episode}</span>}
-        </button>
-      )}
-
-      {showSources && state?.sources?.length > 1 && (
-        <div className="remote-sources-panel">
-          {state.sources.map((s: any) => {
-            const isCurrent = s.infoHash === state.infoHash;
-            return (
-              <button
-                key={s.infoHash}
-                className={`remote-source-item${isCurrent ? " active" : ""}`}
-                onClick={() => {
-                  if (!isCurrent) {
-                    sendCommand("switch-source", s);
-                    setShowSources(false);
-                  }
-                }}
-              >
-                <div className="remote-source-item-name">
-                  {s.name}
-                </div>
-                <div className="remote-source-item-meta">
-                  {isCurrent && <span className="remote-source-tag current">Playing</span>}
-                  {s.tags?.filter((t: string) => t !== "Native").map((t: string) => (
-                    <span key={t} className="remote-source-tag">{t}</span>
-                  ))}
-                  <span className="remote-source-seeds">
-                    <span className="remote-source-seed-dot" />
-                    {s.seeders ?? "?"}
-                  </span>
-                  {s.size > 0 && <span className="remote-source-size">{formatBytes(s.size)}</span>}
-                </div>
-              </button>
-            );
-          })}
-        </div>
-      )}
-
-      {showEpisodes && state?.mediaType === "tv" && (
-        <div className="remote-episodes-panel">
-          {(state.seasonCount > 1 || epBrowserSeason !== state.season) && (
-            <div className="remote-episodes-season-bar">
-              {Array.from({ length: state.seasonCount || 1 }, (_, i) => i + 1).map((s) => (
-                <button
-                  key={s}
-                  className={`remote-episodes-season-btn${s === epBrowserSeason ? " active" : ""}`}
-                  onClick={() => switchEpBrowserSeason(s)}
-                >
-                  S{s}
-                </button>
-              ))}
-            </div>
-          )}
-          <div className="remote-episodes-list">
-            {epBrowserEps === null ? (
-              <div className="remote-episodes-loading"><div className="remote-spinner" /></div>
-            ) : epBrowserEps.length === 0 ? (
-              <div className="remote-episodes-empty">No episodes found</div>
-            ) : (
-              epBrowserEps.map((ep: any) => {
-                const epKey = `s${epBrowserSeason}e${ep.episode_number}`;
-                const prog = epProgress.get(epKey);
-                const pct = prog && prog.duration > 0 ? Math.min(100, (prog.position / prog.duration) * 100) : 0;
-                const isCurrent = epBrowserSeason === state.season && ep.episode_number === state.episode;
-                return (
-                  <button
-                    key={ep.id}
-                    className={`remote-ep-item${isCurrent ? " current" : ""}${prog?.finished ? " watched" : ""}`}
-                    onClick={() => playEpisode(epBrowserSeason, ep.episode_number)}
-                    disabled={isDisabled || isCurrent}
-                  >
-                    <span className="remote-ep-num">E{ep.episode_number}</span>
-                    <div className="remote-ep-info">
-                      <span className="remote-ep-title">{ep.name}</span>
-                      {ep.runtime && <span className="remote-ep-runtime">{ep.runtime}m</span>}
-                    </div>
-                    {isCurrent && (
-                      <span className="remote-ep-playing">
-                        <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor"><path d="M8 5v14l11-7z" /></svg>
-                      </span>
-                    )}
-                    {prog?.finished && !isCurrent && (
-                      <svg className="remote-ep-check" viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
-                        <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
-                      </svg>
-                    )}
-                    {pct > 0 && !prog?.finished && (
-                      <div className="remote-ep-progress">
-                        <div className="remote-ep-progress-fill" style={{ width: `${pct}%` }} />
-                      </div>
-                    )}
-                  </button>
-                );
-              })
-            )}
-          </div>
-        </div>
+        </section>
       )}
 
       <div className="remote-bottom-row">

--- a/test/binge-coordinator.test.ts
+++ b/test/binge-coordinator.test.ts
@@ -77,6 +77,39 @@ describe("BingeCoordinator", () => {
     assert.ok(["advancing", "idle"].includes(c.state));
   });
 
+  it("time-based EOF fallback advances when outroStart is null and t is within 1s of duration", async () => {
+    const { deps, bingeEvents } = makeDeps({
+      getMarkers: () => ({
+        introStart: null, introEnd: null, outroStart: null,
+        outroSource: "no signal — advance on EOF" as const,
+        introSource: "no IntroDB data" as const,
+      }),
+    });
+    const c = new BingeCoordinator(deps);
+    c.setBingeEnabled(true);
+    c.onEpisodeStart({ duration: 2761, currentTime: 0 });
+    c.onTimeUpdate(2760);
+    await new Promise(r => setImmediate(r));
+    assert.ok(bingeEvents.some(e => e.kind === "advance-start"));
+    assert.ok(["advancing", "idle"].includes(c.state));
+  });
+
+  it("time-based EOF fallback does NOT fire when outroStart is set", async () => {
+    const { deps, bingeEvents } = makeDeps({
+      getMarkers: () => ({
+        introStart: null, introEnd: null, outroStart: 1300,
+        outroSource: "chapter markers" as const,
+        introSource: "no IntroDB data" as const,
+      }),
+    });
+    const c = new BingeCoordinator(deps);
+    c.setBingeEnabled(true);
+    c.onEpisodeStart({ duration: 1380, currentTime: 0 });
+    c.onTimeUpdate(1200); // before outroStart and before near-EOF window
+    await new Promise(r => setImmediate(r));
+    assert.ok(!bingeEvents.some(e => e.kind === "advance-start"));
+  });
+
   it("transitions to stopped on prefetch terminal failure", async () => {
     const { deps } = makeDeps({
       startPrefetch: async () => { throw new Error("no sources"); },

--- a/test/lib/anime-detect.test.ts
+++ b/test/lib/anime-detect.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { isAnime, _setTmdbFetcher } from "../../lib/media/anime-detect.js";
+import { tmdbCache } from "../../lib/cache/cache.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFn = any;
+
+describe("isAnime", () => {
+  beforeEach(() => {
+    tmdbCache.clear();
+    _setTmdbFetcher(null);
+  });
+
+  it("returns true for JP origin with Animation genre", async () => {
+    _setTmdbFetcher((async () => ({
+      origin_country: ["JP"],
+      genres: [{ id: 16, name: "Animation" }, { id: 10765, name: "Sci-Fi & Fantasy" }],
+    })) as AnyFn);
+    assert.equal(await isAnime("1429"), true);
+  });
+
+  it("returns false for JP origin without Animation genre", async () => {
+    _setTmdbFetcher((async () => ({
+      origin_country: ["JP"],
+      genres: [{ id: 18, name: "Drama" }],
+    })) as AnyFn);
+    assert.equal(await isAnime("99"), false);
+  });
+
+  it("returns false for Animation genre but non-JP origin", async () => {
+    _setTmdbFetcher((async () => ({
+      origin_country: ["US"],
+      genres: [{ id: 16, name: "Animation" }],
+    })) as AnyFn);
+    assert.equal(await isAnime("1234"), false);
+  });
+
+  it("returns false when tmdb fetch throws", async () => {
+    _setTmdbFetcher((async () => { throw new Error("TMDB_API_KEY not set"); }) as AnyFn);
+    assert.equal(await isAnime("1429"), false);
+  });
+
+  it("returns false on missing fields", async () => {
+    _setTmdbFetcher((async () => ({})) as AnyFn);
+    assert.equal(await isAnime("1"), false);
+  });
+
+  it("caches the result across calls", async () => {
+    let calls = 0;
+    _setTmdbFetcher((async () => {
+      calls++;
+      return { origin_country: ["JP"], genres: [{ id: 16, name: "Animation" }] };
+    }) as AnyFn);
+    assert.equal(await isAnime("5114"), true);
+    assert.equal(await isAnime("5114"), true);
+    assert.equal(calls, 1);
+  });
+});

--- a/test/lib/episode-markers.test.ts
+++ b/test/lib/episode-markers.test.ts
@@ -12,6 +12,7 @@ describe("computeMarkers — priority fall-through", () => {
         { time: 1260, title: "Ending" },
       ],
       aniskip: null,
+      introdb: null,
       learnedOutroOffset: null,
       fileDuration: 1380,
     });
@@ -27,6 +28,7 @@ describe("computeMarkers — priority fall-through", () => {
       bridgeHasChapterSupport: true,
       chapters: [],
       aniskip: { opStart: 20, opEnd: 110, edStart: 1300, episodeLength: 1380 },
+      introdb: null,
       learnedOutroOffset: null,
       fileDuration: 1380,
     });
@@ -41,6 +43,7 @@ describe("computeMarkers — priority fall-through", () => {
       bridgeHasChapterSupport: true,
       chapters: [],
       aniskip: { opStart: 20, opEnd: 110, edStart: 1300, episodeLength: 1380 },
+      introdb: null,
       learnedOutroOffset: null,
       fileDuration: 1430,
     });
@@ -54,6 +57,7 @@ describe("computeMarkers — priority fall-through", () => {
       bridgeHasChapterSupport: true,
       chapters: [],
       aniskip: null,
+      introdb: null,
       learnedOutroOffset: { offset: 1295, sampleCount: 3 },
       fileDuration: 1380,
     });
@@ -66,6 +70,7 @@ describe("computeMarkers — priority fall-through", () => {
       bridgeHasChapterSupport: false,
       chapters: [],
       aniskip: null,
+      introdb: null,
       learnedOutroOffset: null,
       fileDuration: 1380,
     });
@@ -77,6 +82,7 @@ describe("computeMarkers — priority fall-through", () => {
       bridgeHasChapterSupport: true,
       chapters: [],
       aniskip: { opStart: 20, opEnd: 110, edStart: 1300, episodeLength: 1380 },
+      introdb: null,
       learnedOutroOffset: null,
       fileDuration: 1410,
     });
@@ -88,6 +94,7 @@ describe("computeMarkers — priority fall-through", () => {
       bridgeHasChapterSupport: true,
       chapters: [],
       aniskip: { opStart: 20, opEnd: 110, edStart: 1300, episodeLength: 1380 },
+      introdb: null,
       learnedOutroOffset: null,
       fileDuration: 1410.01,
     });
@@ -105,6 +112,7 @@ describe("computeMarkers — priority fall-through", () => {
         { time: 1200, title: "Part 2" },
       ],
       aniskip: null,
+      introdb: null,
       learnedOutroOffset: null,
       fileDuration: 1380,
     });
@@ -120,10 +128,119 @@ describe("computeMarkers — priority fall-through", () => {
         { time: 1200, title: "Ending" },
       ],
       aniskip: null,
+      introdb: null,
       learnedOutroOffset: null,
       fileDuration: 1380,
     });
     assert.equal(m.introStart, null);
     assert.equal(m.outroStart, 1200);
+  });
+});
+
+describe("computeMarkers — IntroDB source", () => {
+  it("uses IntroDB when AniSkip absent", () => {
+    const m = computeMarkers({
+      bridgeHasChapterSupport: true,
+      chapters: [],
+      aniskip: null,
+      introdb: {
+        introStart: 10, introEnd: 80, outroStart: 1290,
+        introSubmissionCount: 5, outroSubmissionCount: 3,
+      },
+      learnedOutroOffset: null,
+      fileDuration: 1380,
+    });
+    assert.equal(m.introStart, 10);
+    assert.equal(m.introEnd, 80);
+    assert.equal(m.outroStart, 1290);
+    assert.equal(m.introSource, "IntroDB · ok");
+    assert.equal(m.outroSource, "IntroDB · ok");
+  });
+
+  it("AniSkip wins over IntroDB when both present and duration matches", () => {
+    const m = computeMarkers({
+      bridgeHasChapterSupport: true,
+      chapters: [],
+      aniskip: { opStart: 20, opEnd: 110, edStart: 1300, episodeLength: 1380 },
+      introdb: {
+        introStart: 5, introEnd: 60, outroStart: 1200,
+        introSubmissionCount: 5, outroSubmissionCount: 5,
+      },
+      learnedOutroOffset: null,
+      fileDuration: 1380,
+    });
+    assert.equal(m.introStart, 20);
+    assert.equal(m.outroStart, 1300);
+    assert.equal(m.introSource, "AniSkip · duration OK");
+    assert.equal(m.outroSource, "AniSkip · duration OK");
+  });
+
+  it("partial merge: AniSkip OP + IntroDB outro when AniSkip has no ED", () => {
+    const m = computeMarkers({
+      bridgeHasChapterSupport: true,
+      chapters: [],
+      aniskip: { opStart: 20, opEnd: 110, edStart: 0, episodeLength: 1380 },
+      introdb: {
+        introStart: null, introEnd: null, outroStart: 1295,
+        introSubmissionCount: 0, outroSubmissionCount: 4,
+      },
+      learnedOutroOffset: null,
+      fileDuration: 1380,
+    });
+    assert.equal(m.introStart, 20);
+    assert.equal(m.introEnd, 110);
+    assert.equal(m.outroStart, 1295);
+    assert.equal(m.introSource, "AniSkip · duration OK");
+    assert.equal(m.outroSource, "IntroDB · ok");
+  });
+
+  it("AniSkip duration mismatch — IntroDB fills both axes", () => {
+    const m = computeMarkers({
+      bridgeHasChapterSupport: true,
+      chapters: [],
+      aniskip: { opStart: 20, opEnd: 110, edStart: 1300, episodeLength: 1380 },
+      introdb: {
+        introStart: 12, introEnd: 70, outroStart: 1285,
+        introSubmissionCount: 4, outroSubmissionCount: 4,
+      },
+      learnedOutroOffset: null,
+      fileDuration: 1430,
+    });
+    assert.equal(m.introStart, 12);
+    assert.equal(m.outroStart, 1285);
+    assert.equal(m.introSource, "IntroDB · ok");
+    assert.equal(m.outroSource, "IntroDB · ok");
+  });
+
+  it("IntroDB absent, AniSkip absent → learned-outro fallback still applies", () => {
+    const m = computeMarkers({
+      bridgeHasChapterSupport: true,
+      chapters: [],
+      aniskip: null,
+      introdb: null,
+      learnedOutroOffset: { offset: 1295, sampleCount: 3 },
+      fileDuration: 1380,
+    });
+    assert.equal(m.outroStart, 1295);
+    assert.equal(m.outroSource, "learned outro offset");
+    assert.equal(m.introSource, "no IntroDB data");
+  });
+
+  it("IntroDB intro only — outro falls to learned-outro", () => {
+    const m = computeMarkers({
+      bridgeHasChapterSupport: true,
+      chapters: [],
+      aniskip: null,
+      introdb: {
+        introStart: 10, introEnd: 60, outroStart: null,
+        introSubmissionCount: 4, outroSubmissionCount: 0,
+      },
+      learnedOutroOffset: { offset: 1290, sampleCount: 2 },
+      fileDuration: 1380,
+    });
+    assert.equal(m.introStart, 10);
+    assert.equal(m.introSource, "IntroDB · ok");
+    assert.equal(m.outroStart, 1290);
+    assert.equal(m.outroSource, "learned outro offset");
   });
 });

--- a/test/lib/introdb.test.ts
+++ b/test/lib/introdb.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { lookupIntrodbMarkers, _setFetcher } from "../../lib/media/introdb.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFn = any;
+
+describe("lookupIntrodbMarkers", () => {
+  beforeEach(() => { _setFetcher(null); });
+
+  it("returns intro and outro when both pass the submission floor", async () => {
+    _setFetcher((async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        imdb_id: "tt0944947", season: 1, episode: 1,
+        intro: { start_ms: 2500, end_ms: 58000, start_sec: 2.5, end_sec: 58, confidence: 0.9, submission_count: 5 },
+        recap: null,
+        outro: { start_ms: 1300000, end_ms: 1380000, start_sec: 1300, end_sec: 1380, confidence: 0.8, submission_count: 3 },
+      }),
+    })) as AnyFn);
+
+    const r = await lookupIntrodbMarkers("tt0944947", 1, 1);
+    assert.ok(r);
+    assert.deepEqual(r!.intro, { startSec: 2.5, endSec: 58, confidence: 0.9, submissionCount: 5 });
+    assert.deepEqual(r!.outro, { startSec: 1300, endSec: 1380, confidence: 0.8, submissionCount: 3 });
+    assert.equal(r!.imdbId, "tt0944947");
+  });
+
+  it("drops segments below submission floor (intro kept, outro dropped)", async () => {
+    _setFetcher((async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        intro: { start_sec: 10, end_sec: 40, confidence: 0.7, submission_count: 2 },
+        recap: null,
+        outro: { start_sec: 1200, end_sec: 1260, confidence: 0.5, submission_count: 1 },
+      }),
+    })) as AnyFn);
+
+    const r = await lookupIntrodbMarkers("tt0944947", 1, 1);
+    assert.ok(r);
+    assert.ok(r!.intro);
+    assert.equal(r!.outro, null);
+  });
+
+  it("returns null when no segments pass the floor", async () => {
+    _setFetcher((async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        intro: { start_sec: 10, end_sec: 40, confidence: 0.5, submission_count: 1 },
+        recap: null,
+        outro: null,
+      }),
+    })) as AnyFn);
+
+    const r = await lookupIntrodbMarkers("tt0944947", 1, 1);
+    assert.equal(r, null);
+  });
+
+  it("returns null on 404", async () => {
+    _setFetcher((async () => ({ ok: false, status: 404, json: async () => ({}) })) as AnyFn);
+    assert.equal(await lookupIntrodbMarkers("tt0000000", 1, 1), null);
+  });
+
+  it("returns null on non-2xx", async () => {
+    _setFetcher((async () => ({ ok: false, status: 500, json: async () => ({}) })) as AnyFn);
+    assert.equal(await lookupIntrodbMarkers("tt0944947", 1, 1), null);
+  });
+
+  it("returns null on network error", async () => {
+    _setFetcher((async () => { throw new Error("fetch failed"); }) as AnyFn);
+    assert.equal(await lookupIntrodbMarkers("tt0944947", 1, 1), null);
+  });
+
+  it("ignores recap segment even when passing the floor", async () => {
+    _setFetcher((async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        intro: null,
+        recap: { start_sec: 0, end_sec: 30, confidence: 0.9, submission_count: 10 },
+        outro: null,
+      }),
+    })) as AnyFn);
+
+    // Only intro/outro count for the floor check; recap being present should not rescue the response.
+    const r = await lookupIntrodbMarkers("tt0944947", 1, 1);
+    assert.equal(r, null);
+  });
+
+  it("sends the expected URL", async () => {
+    let capturedUrl = "";
+    _setFetcher((async (url: string) => {
+      capturedUrl = url;
+      return { ok: false, status: 404, json: async () => ({}) };
+    }) as AnyFn);
+    await lookupIntrodbMarkers("tt0944947", 3, 7);
+    assert.equal(capturedUrl, "https://api.introdb.app/segments?imdb_id=tt0944947&season=3&episode=7");
+  });
+});

--- a/test/routes/media.test.ts
+++ b/test/routes/media.test.ts
@@ -122,4 +122,20 @@ describe("Media routes", () => {
       }
     });
   });
+
+  describe("GET /api/episode-markers", () => {
+    it("returns 400 when required params missing", async () => {
+      const res = await fetch(`${baseUrl}/api/episode-markers`);
+      assert.equal(res.status, 400);
+    });
+
+    it("returns 200 with nulls when no params resolve data", async () => {
+      const url = `${baseUrl}/api/episode-markers?title=NoSuchShow&episode=1&duration=1400&season=1`;
+      const res = await fetch(url);
+      assert.equal(res.status, 200);
+      const body = await res.json() as { aniskip: unknown; introdb: unknown };
+      assert.equal(body.aniskip, null);
+      assert.equal(body.introdb, null);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **IntroDB integration** — new IntroDB client with submission-count floor, TMDB-based JP+Animation classifier, and `computeMarkers` extended to merge IntroDB with existing sources
- **Episode markers API** — `/api/aniskip-markers` replaced by `/api/episode-markers` (returns unified intro/outro data from AniSkip + IntroDB); Player and Remote rewired to the new route with introdb diagnostics
- **Binge mode fixes** — time-based EOF fallback when reported duration overstates the actual stream end; audio/subtitle picks now persist across auto-advance; section hidden for movie sessions; state replayed on every SSE connect so the toggle survives a remote remount (navigating away and back)
- **Phone remote UI** — controls grouped into labeled sections (Audio / Subtitles / Content / Binge Mode), iOS-style toggle switch, collapsible features list, diagnostics hidden behind `?dev=1`, aria-labels throughout
- **Phone remote polish** — scoped contrast bump on labels/hints (muted/secondary tokens now read above 7:1 on the remote surface), brighter BETA badge with clearer typography

## Test plan

- [ ] `/api/episode-markers?...` returns intro/outro with `source` field populated from both AniSkip and IntroDB where available
- [ ] Binge capabilities show the correct source + sample count for IntroDB-backed shows
- [ ] Anime detection (TMDB JP + Animation) routes to IntroDB/AniSkip correctly for non-AniSkip anime
- [ ] Auto-advance preserves the active audio/subtitle selections across episode transitions
- [ ] EOF fallback fires when `currentTime` approaches actual stream end even if `duration` is inflated
- [ ] Binge Mode section does not render for movie playback
- [ ] Enable binge mode on the phone, navigate to Browse and back to /remote — toggle stays on and features panel repopulates without re-toggling
- [ ] On phone, remote shows labeled Audio/Subtitles/Content/Binge Mode sections
- [ ] Binge features list collapses by default; clicking expands the 5-feature list
- [ ] Binge diagnostics only appear with `?dev=1` or `localStorage['rattin.remoteDev'] = '1'`
- [ ] Episodes, Next Ep, and Sources render as compact side-by-side buttons (not full-width)
- [ ] Section labels ("AUDIO", "CONTENT", "BINGE MODE"), control labels ("Volume", "Track"), and meta text ("S1E2", peer counts) are clearly legible on the dark remote background

🤖 Generated with [Claude Code](https://claude.com/claude-code)