### PR TITLE
fix(rc): use kernel routing table for LAN IP detection

### DIFF
--- a/lib/torrent/debrid.ts
+++ b/lib/torrent/debrid.ts
@@ -11,7 +11,7 @@ export interface DebridFileInfo {
   bytes: number;
 }
 
-export interface DebridStream {
+interface DebridStream {
   url: string;
   filename: string;
   filesize: number;

--- a/lib/torrent/prefetch.ts
+++ b/lib/torrent/prefetch.ts
@@ -34,15 +34,3 @@ export async function startPrefetch(args: PrefetchArgs): Promise<Resolved | null
   return resolved;
 }
 
-export async function isDebridCached(
-  poll: () => Promise<boolean>,
-  timeoutMs = 10_000,
-  intervalMs = 1_000,
-): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await poll()) return true;
-    await new Promise(r => setTimeout(r, intervalMs));
-  }
-  return false;
-}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -294,10 +294,6 @@ export interface TorrentResult {
   provider?: string;
 }
 
-export interface ScoredTorrent extends TorrentResult {
-  score: number;
-  tags: string[];
-}
 
 // ── Cache ─────────────────────────────────────────────────────────────
 

--- a/routes/rc.ts
+++ b/routes/rc.ts
@@ -1,9 +1,34 @@
 import crypto from "crypto";
+import dgram from "dgram";
 import os from "os";
 import type { Express, Request, Response } from "express";
 import { buildCookie, clearCookie, getRcAuthToken, getRcSessionId } from "../lib/access-control.js";
 import type { ServerContext, RCSession, RCClient, BingeCapabilities, BingeDiagnostics, PersistedTracks } from "../lib/types.js";
 import { dumpRcSessions } from "../lib/storage/rc-sessions.js";
+
+/** Get the LAN IP the kernel would use to reach the internet.
+ *  Works by connecting a UDP socket to a public address (no packets sent)
+ *  and reading the locally bound address — the kernel picks the correct
+ *  interface based on the routing table. VirtualBox/Docker host-only
+ *  adapters never carry default routes, so they are never returned. */
+function getLanIp(): Promise<string> {
+  return new Promise((resolve) => {
+    const sock = dgram.createSocket("udp4");
+    let resolved = false;
+    const done = (addr: string) => {
+      if (resolved) return;
+      resolved = true;
+      try { sock.close(); } catch {}
+      resolve(addr);
+    };
+    sock.on("error", () => done(""));
+    sock.connect(80, "1.1.1.1", () => {
+      const addr = sock.address();
+      done(addr && typeof addr === "object" ? addr.address : "");
+    });
+    setTimeout(() => done(""), 2000);
+  });
+}
 
 export default function rcRoutes(app: Express, ctx: ServerContext): void {
   const { log, pcAuthToken, rcSessions } = ctx;
@@ -116,18 +141,32 @@ export default function rcRoutes(app: Express, ctx: ServerContext): void {
     }
   });
 
-  // LAN IP for phone remote pairing (native shell binds to 0.0.0.0 but QR needs a real IP)
-  app.get("/api/rc/lan-ip", (_req: Request, res: Response) => {
-    const interfaces = os.networkInterfaces();
-    for (const addrs of Object.values(interfaces)) {
-      if (!addrs) continue;
-      for (const addr of addrs) {
-        if (addr.family === "IPv4" && !addr.internal) {
-          return res.json({ ip: addr.address, port: Number(process.env.PORT) || 3000 });
+  // LAN IP for phone remote pairing — uses kernel routing table so virtual
+  // adapters (VirtualBox, Docker, VPNs) are never picked up. Falls back to
+  // interface iteration if the machine is offline.
+  app.get("/api/rc/lan-ip", async (_req: Request, res: Response) => {
+    const port = Number(process.env.PORT) || 3000;
+    let ip = await getLanIp();
+
+    // Fallback: offline/no default route — iterate interfaces.
+    if (!ip) {
+      const ifaces = os.networkInterfaces();
+      outer:
+      for (const [name, addrs] of Object.entries(ifaces)) {
+        if (!addrs) continue;
+        // Skip known virtual/host-only adapters (cross-platform)
+        if (/^(vboxnet|vmnet|docker|virbr|tun|tap|veth|br-|utun|llw|awdl|anpi|bridge|lo$)/i.test(name)) continue;
+        if (/(VirtualBox|vEthernet|Hyper-V|VMware|WSL)/i.test(name)) continue;
+        for (const addr of addrs) {
+          if (addr.family === "IPv4" && !addr.internal) {
+            ip = addr.address;
+            break outer;
+          }
         }
       }
     }
-    res.json({ ip: null, port: Number(process.env.PORT) || 3000 });
+
+    res.json({ ip: ip || null, port });
   });
 
   // Session status probe (used by phone to detect expired sessions)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -246,15 +246,6 @@ export async function deleteDebridConfig(): Promise<void> {
   if (!res.ok) throw new Error("delete_failed");
 }
 
-export async function checkDebridCached(infoHashes: string[]): Promise<Record<string, boolean>> {
-  const res = await fetch("/api/debrid/cached", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ infoHashes }),
-  });
-  const data = await res.json();
-  return data.cached || {};
-}
 
 // ── TMDB ──────────────────────────────────────────────────────────
 
@@ -299,10 +290,6 @@ export function fetchContinueWatching(): Promise<{ items: any[] }> {
   return get("/api/watch-history/continue");
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function fetchRecentlyWatched(): Promise<{ items: any[] }> {
-  return get("/api/watch-history/recent");
-}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function fetchSeriesProgress(tmdbId: number): Promise<{ episodes: any[] }> {
@@ -383,10 +370,6 @@ export async function toggleVpn(action: "on" | "off"): Promise<void> {
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function verifyVpn(): Promise<any> {
-  return get("/api/vpn/verify");
-}
 
 export async function uploadSubtitle(file: File): Promise<{ url: string }> {
   const res = await fetch(`/api/subtitle/upload?filename=${encodeURIComponent(file.name)}`, {

--- a/src/lib/home-cache.ts
+++ b/src/lib/home-cache.ts
@@ -29,13 +29,3 @@ export function setHomeCache(key: string, data: any): void {
   }
 }
 
-export function clearHomeCache(): void {
-  try {
-    const keys: string[] = [];
-    for (let i = 0; i < localStorage.length; i++) {
-      const k = localStorage.key(i);
-      if (k && k.startsWith(PREFIX)) keys.push(k);
-    }
-    keys.forEach((k) => localStorage.removeItem(k));
-  } catch {}
-}

--- a/src/lib/native-bridge.ts
+++ b/src/lib/native-bridge.ts
@@ -47,7 +47,6 @@ interface MpvEvents {
   onIsPlayingChanged: ((playing: boolean) => void) | null;
   onNativeSubChanged: ((mpvId: number) => void) | null;
   onNativeAudioChanged: ((mpvId: number) => void) | null;
-  onNativeVolumeChanged: ((percent: number) => void) | null;
   onNativeSubSizeChanged: ((size: number) => void) | null;
   onNativeSubDelayChanged: ((delay: number) => void) | null;
   onToggleSourcePanel: (() => void) | null;
@@ -92,7 +91,6 @@ export function waitForBridge(): Promise<void> {
           onIsPlayingChanged: null,
           onNativeSubChanged: null,
           onNativeAudioChanged: null,
-          onNativeVolumeChanged: null,
           onNativeSubSizeChanged: null,
           onNativeSubDelayChanged: null,
           onToggleSourcePanel: null,
@@ -119,9 +117,6 @@ export function waitForBridge(): Promise<void> {
         });
         bridge.nativeAudioChanged.connect((mpvId: number) => {
           if (window.mpvEvents?.onNativeAudioChanged) window.mpvEvents.onNativeAudioChanged(mpvId);
-        });
-        bridge.nativeVolumeChanged.connect((percent: number) => {
-          if (window.mpvEvents?.onNativeVolumeChanged) window.mpvEvents.onNativeVolumeChanged(percent);
         });
         bridge.nativeSubSizeChanged.connect((size: number) => {
           if (window.mpvEvents?.onNativeSubSizeChanged) window.mpvEvents.onNativeSubSizeChanged(size);
@@ -255,9 +250,6 @@ export function onNativeAudioChanged(cb: (mpvId: number) => void): void {
   if (window.mpvEvents) window.mpvEvents.onNativeAudioChanged = cb;
 }
 
-export function onNativeVolumeChanged(cb: (percent: number) => void): void {
-  if (window.mpvEvents) window.mpvEvents.onNativeVolumeChanged = cb;
-}
 
 export function onNativeSubSizeChanged(cb: (size: number) => void): void {
   if (window.mpvEvents) window.mpvEvents.onNativeSubSizeChanged = cb;


### PR DESCRIPTION
## Problem
`/api/rc/lan-ip` used `os.networkInterfaces()` and returned the **first** non-internal IPv4 address found. After installing VirtualBox, the `vboxnet0` host-only adapter (`192.168.56.x`) could be enumerated before the real LAN interface, causing the phone remote QR code to encode the wrong IP — unreachable from the phone.

Same issue affects Docker (`docker0`), VMware (`vmnet*`), Hyper-V, WSL, and VPN tunnel adapters on all platforms.

## Changes

### `routes/rc.ts` — LAN IP detection fix (+48/-9)
**Primary:** Uses a connected UDP socket (`dgram.createSocket("udp4").connect()`) to ask the kernel which local IP it would use to reach the internet. VirtualBox/Docker host-only adapters don't carry default routes, so they are never returned. No actual packets are sent — `connect()` only binds a default destination.

**Fallback:** If the machine is offline (no default route), iterates interfaces with a regex filter that skips known virtual adapter names cross-platform (Linux/macOS/Windows).

Zero new dependencies (Node.js built-in `dgram` and `os` only). API contract unchanged.

### `lib/torrent/debrid.ts` — unexport `DebridStream` interface
`DebridStream` was only used internally within `debrid.ts`. Unexported to reduce API surface. No external consumers.

### `lib/torrent/prefetch.ts` — remove `isDebridCached()`
Dead code — no remaining callers.

### `lib/types.ts` — remove `ScoredTorrent` interface
Dead code — no remaining references.

### `src/lib/api.ts` — remove `checkDebridCached()`, `fetchRecentlyWatched()`, `verifyVpn()`
Dead code — no remaining callers or routes.

### `src/lib/home-cache.ts` — remove `clearHomeCache()`
Dead code — no remaining callers.

### `src/lib/native-bridge.ts` — remove `onNativeVolumeChanged`
Dead event handler — no corresponding signal from the native bridge.

## Verification
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] No broken imports (grep verified across full repo)
- [ ] Manual test: start server, `curl /api/rc/lan-ip`, verify IP is real LAN IP (not `192.168.56.x`)