### PR TITLE
fix(rc): use kernel routing table for LAN IP detection

### DIFF
--- a/routes/rc.ts
+++ b/routes/rc.ts
@@ -1,9 +1,34 @@
 import crypto from "crypto";
+import dgram from "dgram";
 import os from "os";
 import type { Express, Request, Response } from "express";
 import { buildCookie, clearCookie, getRcAuthToken, getRcSessionId } from "../lib/access-control.js";
 import type { ServerContext, RCSession, RCClient, BingeCapabilities, BingeDiagnostics, PersistedTracks } from "../lib/types.js";
 import { dumpRcSessions } from "../lib/storage/rc-sessions.js";
+
+/** Get the LAN IP the kernel would use to reach the internet.
+ *  Works by connecting a UDP socket to a public address (no packets sent)
+ *  and reading the locally bound address — the kernel picks the correct
+ *  interface based on the routing table. VirtualBox/Docker host-only
+ *  adapters never carry default routes, so they are never returned. */
+function getLanIp(): Promise<string> {
+  return new Promise((resolve) => {
+    const sock = dgram.createSocket("udp4");
+    let resolved = false;
+    const done = (addr: string) => {
+      if (resolved) return;
+      resolved = true;
+      try { sock.close(); } catch {}
+      resolve(addr);
+    };
+    sock.on("error", () => done(""));
+    sock.connect(80, "1.1.1.1", () => {
+      const addr = sock.address();
+      done(addr && typeof addr === "object" ? addr.address : "");
+    });
+    setTimeout(() => done(""), 2000);
+  });
+}
 
 export default function rcRoutes(app: Express, ctx: ServerContext): void {
   const { log, pcAuthToken, rcSessions } = ctx;
@@ -116,18 +141,32 @@ export default function rcRoutes(app: Express, ctx: ServerContext): void {
     }
   });
 
-  // LAN IP for phone remote pairing (native shell binds to 0.0.0.0 but QR needs a real IP)
-  app.get("/api/rc/lan-ip", (_req: Request, res: Response) => {
-    const interfaces = os.networkInterfaces();
-    for (const addrs of Object.values(interfaces)) {
-      if (!addrs) continue;
-      for (const addr of addrs) {
-        if (addr.family === "IPv4" && !addr.internal) {
-          return res.json({ ip: addr.address, port: Number(process.env.PORT) || 3000 });
+  // LAN IP for phone remote pairing — uses kernel routing table so virtual
+  // adapters (VirtualBox, Docker, VPNs) are never picked up. Falls back to
+  // interface iteration if the machine is offline.
+  app.get("/api/rc/lan-ip", async (_req: Request, res: Response) => {
+    const port = Number(process.env.PORT) || 3000;
+    let ip = await getLanIp();
+
+    // Fallback: offline/no default route — iterate interfaces.
+    if (!ip) {
+      const ifaces = os.networkInterfaces();
+      outer:
+      for (const [name, addrs] of Object.entries(ifaces)) {
+        if (!addrs) continue;
+        // Skip known virtual/host-only adapters (cross-platform)
+        if (/^(vboxnet|vmnet|docker|virbr|tun|tap|veth|br-|utun|llw|awdl|anpi|bridge|lo$)/i.test(name)) continue;
+        if (/(VirtualBox|vEthernet|Hyper-V|VMware|WSL)/i.test(name)) continue;
+        for (const addr of addrs) {
+          if (addr.family === "IPv4" && !addr.internal) {
+            ip = addr.address;
+            break outer;
+          }
         }
       }
     }
-    res.json({ ip: null, port: Number(process.env.PORT) || 3000 });
+
+    res.json({ ip: ip || null, port });
   });
 
   // Session status probe (used by phone to detect expired sessions)


### PR DESCRIPTION
## Problem
`/api/rc/lan-ip` used `os.networkInterfaces()` and returned the **first** non-internal IPv4 address found. After installing VirtualBox, the `vboxnet0` host-only adapter (`192.168.56.x`) could be enumerated before the real LAN interface, causing the phone remote QR code to encode the wrong IP — unreachable from the phone.

Same issue affects Docker, VMware, Hyper-V, WSL, and VPN tunnel adapters on all platforms.

## Fix
**Primary:** Uses a connected UDP socket (`dgram.createSocket("udp4").connect()`) to ask the kernel which local IP it would use to reach the internet. VirtualBox/Docker host-only adapters don't carry default routes, so they are never returned. No actual packets are sent — `connect()` only binds a default destination.

**Fallback:** If the machine is offline (no default route), iterates interfaces with a regex filter that skips known virtual adapter names cross-platform:
- Linux: `vboxnet`, `docker`, `virbr`, `tun`, `tap`, `veth`, `br-`
- macOS: `utun`, `llw`, `awdl`, `anpi`, `bridge`
- Windows: `VirtualBox Host-Only Network`, `vEthernet`, `Hyper-V`, `VMware`, `WSL`
- All platforms: `lo`

## Changes
- `routes/rc.ts` — `+48/-9` lines
- Zero new dependencies (Node.js built-in `dgram` and `os` only)
- API contract unchanged: `{ ip: string | null, port: number }`

## Verification
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Manual test: start server, `curl /api/rc/lan-ip`, verify IP is real LAN IP (not `192.168.56.x`)