### PR TITLE
chore: remove dead frontend and shared exports

### DIFF
--- a/lib/torrent/debrid.ts
+++ b/lib/torrent/debrid.ts
@@ -11,7 +11,7 @@ export interface DebridFileInfo {
   bytes: number;
 }
 
-export interface DebridStream {
+interface DebridStream {
   url: string;
   filename: string;
   filesize: number;

--- a/lib/torrent/prefetch.ts
+++ b/lib/torrent/prefetch.ts
@@ -34,15 +34,3 @@ export async function startPrefetch(args: PrefetchArgs): Promise<Resolved | null
   return resolved;
 }
 
-export async function isDebridCached(
-  poll: () => Promise<boolean>,
-  timeoutMs = 10_000,
-  intervalMs = 1_000,
-): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await poll()) return true;
-    await new Promise(r => setTimeout(r, intervalMs));
-  }
-  return false;
-}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -294,10 +294,6 @@ export interface TorrentResult {
   provider?: string;
 }
 
-export interface ScoredTorrent extends TorrentResult {
-  score: number;
-  tags: string[];
-}
 
 // ── Cache ─────────────────────────────────────────────────────────────
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -246,15 +246,6 @@ export async function deleteDebridConfig(): Promise<void> {
   if (!res.ok) throw new Error("delete_failed");
 }
 
-export async function checkDebridCached(infoHashes: string[]): Promise<Record<string, boolean>> {
-  const res = await fetch("/api/debrid/cached", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ infoHashes }),
-  });
-  const data = await res.json();
-  return data.cached || {};
-}
 
 // ── TMDB ──────────────────────────────────────────────────────────
 
@@ -299,10 +290,6 @@ export function fetchContinueWatching(): Promise<{ items: any[] }> {
   return get("/api/watch-history/continue");
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function fetchRecentlyWatched(): Promise<{ items: any[] }> {
-  return get("/api/watch-history/recent");
-}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function fetchSeriesProgress(tmdbId: number): Promise<{ episodes: any[] }> {
@@ -383,10 +370,6 @@ export async function toggleVpn(action: "on" | "off"): Promise<void> {
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function verifyVpn(): Promise<any> {
-  return get("/api/vpn/verify");
-}
 
 export async function uploadSubtitle(file: File): Promise<{ url: string }> {
   const res = await fetch(`/api/subtitle/upload?filename=${encodeURIComponent(file.name)}`, {

--- a/src/lib/home-cache.ts
+++ b/src/lib/home-cache.ts
@@ -29,13 +29,3 @@ export function setHomeCache(key: string, data: any): void {
   }
 }
 
-export function clearHomeCache(): void {
-  try {
-    const keys: string[] = [];
-    for (let i = 0; i < localStorage.length; i++) {
-      const k = localStorage.key(i);
-      if (k && k.startsWith(PREFIX)) keys.push(k);
-    }
-    keys.forEach((k) => localStorage.removeItem(k));
-  } catch {}
-}

--- a/src/lib/native-bridge.ts
+++ b/src/lib/native-bridge.ts
@@ -47,7 +47,6 @@ interface MpvEvents {
   onIsPlayingChanged: ((playing: boolean) => void) | null;
   onNativeSubChanged: ((mpvId: number) => void) | null;
   onNativeAudioChanged: ((mpvId: number) => void) | null;
-  onNativeVolumeChanged: ((percent: number) => void) | null;
   onNativeSubSizeChanged: ((size: number) => void) | null;
   onNativeSubDelayChanged: ((delay: number) => void) | null;
   onToggleSourcePanel: (() => void) | null;
@@ -92,7 +91,6 @@ export function waitForBridge(): Promise<void> {
           onIsPlayingChanged: null,
           onNativeSubChanged: null,
           onNativeAudioChanged: null,
-          onNativeVolumeChanged: null,
           onNativeSubSizeChanged: null,
           onNativeSubDelayChanged: null,
           onToggleSourcePanel: null,
@@ -119,9 +117,6 @@ export function waitForBridge(): Promise<void> {
         });
         bridge.nativeAudioChanged.connect((mpvId: number) => {
           if (window.mpvEvents?.onNativeAudioChanged) window.mpvEvents.onNativeAudioChanged(mpvId);
-        });
-        bridge.nativeVolumeChanged.connect((percent: number) => {
-          if (window.mpvEvents?.onNativeVolumeChanged) window.mpvEvents.onNativeVolumeChanged(percent);
         });
         bridge.nativeSubSizeChanged.connect((size: number) => {
           if (window.mpvEvents?.onNativeSubSizeChanged) window.mpvEvents.onNativeSubSizeChanged(size);
@@ -255,9 +250,6 @@ export function onNativeAudioChanged(cb: (mpvId: number) => void): void {
   if (window.mpvEvents) window.mpvEvents.onNativeAudioChanged = cb;
 }
 
-export function onNativeVolumeChanged(cb: (percent: number) => void): void {
-  if (window.mpvEvents) window.mpvEvents.onNativeVolumeChanged = cb;
-}
 
 export function onNativeSubSizeChanged(cb: (size: number) => void): void {
   if (window.mpvEvents) window.mpvEvents.onNativeSubSizeChanged = cb;


### PR DESCRIPTION
## What
Remove unused exports, interfaces, and functions across the frontend and shared library. All verified via grep — zero remaining callers.

## Changes

| File | Removal |
|------|---------|
| `lib/torrent/debrid.ts` | Unexport `DebridStream` (used only internally) |
| `lib/torrent/prefetch.ts` | Remove `isDebridCached()` |
| `lib/types.ts` | Remove `ScoredTorrent` interface |
| `src/lib/api.ts` | Remove `checkDebridCached()`, `fetchRecentlyWatched()`, `verifyVpn()` |
| `src/lib/home-cache.ts` | Remove `clearHomeCache()` |
| `src/lib/native-bridge.ts` | Remove `onNativeVolumeChanged` handler |

## Verification
- [x] TypeScript compiles clean
- [x] No broken imports (grep verified across full repo)