### PR TITLE
release: 3.0.3 recap fixes and mobile polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rattin",
-  "version": "3.0.0",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rattin",
-      "version": "3.0.0",
+      "version": "3.0.3",
       "license": "GPL-3.0-only",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rattin",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "",
   "type": "module",
   "main": "server.ts",

--- a/src/pages/Detail.css
+++ b/src/pages/Detail.css
@@ -1284,10 +1284,6 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 14px;
-  /* Show one row only — card is ~197px (thumb 124 + meta 71 + border 2).
-     Give buffer so channel/views text isn't clipped. */
-  max-height: 218px;
-  overflow: hidden;
 }
 
 .recap-card {
@@ -1399,8 +1395,19 @@
 @media (max-width: 768px) {
   .recaps-toggle.expanded {
     position: sticky;
-    top: 56px;
+    top: var(--recaps-sticky-top, 56px);
     z-index: 90;
+    transition: width 0.22s ease, margin 0.22s ease, padding 0.22s ease, border-radius 0.22s ease, background 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease;
+  }
+  .recaps-toggle.expanded.is-stuck {
+    width: calc(100% + 32px);
+    margin-left: -16px;
+    margin-right: -16px;
+    padding-left: 16px;
+    padding-right: 16px;
+    border-left: none;
+    border-right: none;
+    border-radius: 0;
     background: rgba(15, 15, 24, 0.94);
     backdrop-filter: blur(16px) saturate(1.05);
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.28);
@@ -1413,8 +1420,6 @@
   }
   .recaps-grid {
     grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-    /* Mobile card is shorter — 160×9/16 thumb + meta + padding */
-    max-height: 178px;
   }
   .recap-featured {
     flex-direction: column;

--- a/src/pages/Detail.css
+++ b/src/pages/Detail.css
@@ -872,10 +872,7 @@
   cursor: pointer;
   font-family: inherit;
   transition: all var(--transition);
-  /* ponytail: sticky under the fixed navbar, not under it */
-  position: sticky;
-  top: 68px;
-  z-index: 90;
+  /* default: not sticky — mobile-only when expanded */
 }
 
 .recaps-toggle:hover {
@@ -1400,8 +1397,13 @@
 
 /* ── Responsive ── */
 @media (max-width: 768px) {
-  .recaps-toggle {
+  .recaps-toggle.expanded {
+    position: sticky;
     top: 56px;
+    z-index: 90;
+    background: rgba(15, 15, 24, 0.94);
+    backdrop-filter: blur(16px) saturate(1.05);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.28);
   }
   .recaps-search-row {
     flex-direction: column;

--- a/src/pages/Detail.css
+++ b/src/pages/Detail.css
@@ -872,11 +872,10 @@
   cursor: pointer;
   font-family: inherit;
   transition: all var(--transition);
-  /* Stick to top when user scrolls past it, so they can collapse
-     without scrolling all the way back up. Only when expanded. */
+  /* ponytail: sticky under the fixed navbar, not under it */
   position: sticky;
-  top: 0;
-  z-index: 10;
+  top: 68px;
+  z-index: 90;
 }
 
 .recaps-toggle:hover {
@@ -1290,7 +1289,7 @@
   gap: 14px;
   /* Show one row only — card is ~197px (thumb 124 + meta 71 + border 2).
      Give buffer so channel/views text isn't clipped. */
-  max-height: 210px;
+  max-height: 218px;
   overflow: hidden;
 }
 
@@ -1401,6 +1400,9 @@
 
 /* ── Responsive ── */
 @media (max-width: 768px) {
+  .recaps-toggle {
+    top: 56px;
+  }
   .recaps-search-row {
     flex-direction: column;
   }
@@ -1410,7 +1412,7 @@
   .recaps-grid {
     grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
     /* Mobile card is shorter — 160×9/16 thumb + meta + padding */
-    max-height: 165px;
+    max-height: 178px;
   }
   .recap-featured {
     flex-direction: column;

--- a/src/pages/Detail.css
+++ b/src/pages/Detail.css
@@ -869,6 +869,11 @@
   cursor: pointer;
   font-family: inherit;
   transition: all var(--transition);
+  /* Stick to top when user scrolls past it, so they can collapse
+     without scrolling all the way back up. Only when expanded. */
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 .recaps-toggle:hover {
@@ -1280,10 +1285,11 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 14px;
-  /* ponytail: show one row only — card is ~168px (220×9/16 thumb + meta),
-     cap with overflow hidden. CSS grid handles column count per breakpoint. */
-  max-height: 182px;
+  /* Show one row only — cap with overflow hidden. Extra padding-bottom
+     so the channel/views text isn't clipped at the edge. */
+  max-height: 200px;
   overflow: hidden;
+  padding-bottom: 8px;
 }
 
 .recap-card {
@@ -1401,8 +1407,8 @@
   }
   .recaps-grid {
     grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-    /* ponytail: mobile card ~134px (160×9/16 thumb + meta) */
-    max-height: 148px;
+    /* Mobile card is shorter — 160×9/16 thumb + meta + padding */
+    max-height: 165px;
   }
   .recap-featured {
     flex-direction: column;

--- a/src/pages/Detail.css
+++ b/src/pages/Detail.css
@@ -1280,6 +1280,10 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 14px;
+  /* ponytail: show one row only — card is ~168px (220×9/16 thumb + meta),
+     cap with overflow hidden. CSS grid handles column count per breakpoint. */
+  max-height: 182px;
+  overflow: hidden;
 }
 
 .recap-card {
@@ -1397,6 +1401,8 @@
   }
   .recaps-grid {
     grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    /* ponytail: mobile card ~134px (160×9/16 thumb + meta) */
+    max-height: 148px;
   }
   .recap-featured {
     flex-direction: column;

--- a/src/pages/Detail.css
+++ b/src/pages/Detail.css
@@ -29,7 +29,10 @@
   z-index: 1;
   margin-top: -200px;
   padding: 0 48px 48px;
-  animation: fadeUp 0.6s ease-out both;
+  /* ponytail: backwards (not both) so the transform doesn't persist
+     after the animation ends — a lingering transform creates a containing
+     block that breaks position:sticky on descendants. */
+  animation: fadeUp 0.6s ease-out backwards;
 }
 
 .detail-main {
@@ -1285,11 +1288,10 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 14px;
-  /* Show one row only — cap with overflow hidden. Extra padding-bottom
-     so the channel/views text isn't clipped at the edge. */
-  max-height: 200px;
+  /* Show one row only — card is ~197px (thumb 124 + meta 71 + border 2).
+     Give buffer so channel/views text isn't clipped. */
+  max-height: 210px;
   overflow: hidden;
-  padding-bottom: 8px;
 }
 
 .recap-card {

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -522,16 +522,15 @@ export default function Detail() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recapSeason]);
 
-  // Measure grid columns from actual rendered width
+  // Measure actual rendered grid columns from the DOM
   useEffect(() => {
     if (!showMoreRecaps) return;
     const grid = recapsGridRef.current;
     if (!grid) return;
     const measure = () => {
-      const style = getComputedStyle(grid);
-      const w = grid.clientWidth - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
-      const colWidth = 220 + 14; // minmax(220px,1fr) + gap
-      setRecapColumns(Math.max(1, Math.floor((w + 14) / colWidth)));
+      const count = window.getComputedStyle(grid)
+        .gridTemplateColumns.split(" ").filter(Boolean).length;
+      if (count > 0) setRecapColumns(count);
     };
     measure();
     const ro = new ResizeObserver(measure);
@@ -885,17 +884,18 @@ export default function Detail() {
                           onClick={() => {
                             if (!showMoreRecaps) {
                               setShowMoreRecaps(true);
-                            } else {
+                            } else if (recapResults.length - 1 > recapRowsShown * recapColumns) {
                               setRecapRowsShown((r) => r + 1);
+                            } else {
+                              setShowMoreRecaps(false);
+                              setRecapRowsShown(1);
                             }
                           }}
                         >
-                          {!showMoreRecaps ? "Show more recaps" : "Show more"}
-                          {(recapResults.length - 1 > recapRowsShown * recapColumns) && (
-                            <span className={`recaps-chevron${showMoreRecaps ? " open" : ""}`}>
-                              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6 6-6" /></svg>
-                            </span>
-                          )}
+                          {!showMoreRecaps ? "Show more recaps" : recapResults.length - 1 > recapRowsShown * recapColumns ? "Show more" : "Show less"}
+                          <span className={`recaps-chevron${showMoreRecaps ? " open" : ""}`}>
+                            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6 6-6" /></svg>
+                          </span>
                         </button>
                         {showMoreRecaps && (
                           <div className="recaps-grid" ref={recapsGridRef}>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -109,10 +109,7 @@ export default function Detail() {
   const [recapExpanded, setRecapExpanded] = useState(false);
   const [recapMinimized, setRecapMinimized] = useState(false);
   const [showMoreRecaps, setShowMoreRecaps] = useState(false);
-  const [recapRowsShown, setRecapRowsShown] = useState(1);
-  const [recapColumns, setRecapColumns] = useState(3);
   const [recapSeason, setRecapSeason] = useState(selectedSeason);
-  const recapsGridRef = useRef<HTMLDivElement>(null);
   const [recoveryKey, setRecoveryKey] = useState(0);
   useRefetchOnRecovery(useCallback(() => setRecoveryKey((k) => k + 1), []));
   const [showPluginPrompt, setShowPluginPrompt] = useState(false);
@@ -130,7 +127,6 @@ export default function Detail() {
     setRecapExpanded(false);
     setRecapMinimized(false);
     setShowMoreRecaps(false);
-    setRecapRowsShown(1);
     setShowAllReddit(false);
     setShowAllReviews(false);
     setResumePoint(null);
@@ -513,7 +509,6 @@ export default function Detail() {
     setSelectedRecap(null);
     setRecapMinimized(false);
     setShowMoreRecaps(false);
-    setRecapRowsShown(1);
     if (recapExpanded && data) {
       const q = `${data.name || data.title} season ${recapSeason} recap`;
       setRecapQuery(q);
@@ -521,22 +516,6 @@ export default function Detail() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recapSeason]);
-
-  // Measure actual rendered grid columns from the DOM
-  useEffect(() => {
-    if (!showMoreRecaps) return;
-    const grid = recapsGridRef.current;
-    if (!grid) return;
-    const measure = () => {
-      const count = window.getComputedStyle(grid)
-        .gridTemplateColumns.split(" ").filter(Boolean).length;
-      if (count > 0) setRecapColumns(count);
-    };
-    measure();
-    const ro = new ResizeObserver(measure);
-    ro.observe(grid);
-    return () => ro.disconnect();
-  }, [showMoreRecaps]);
 
   if (!data) {
     return (
@@ -881,25 +860,16 @@ export default function Detail() {
                       <>
                         <button
                           className="recaps-more-toggle"
-                          onClick={() => {
-                            if (!showMoreRecaps) {
-                              setShowMoreRecaps(true);
-                            } else if (recapResults.length - 1 > recapRowsShown * recapColumns) {
-                              setRecapRowsShown((r) => r + 1);
-                            } else {
-                              setShowMoreRecaps(false);
-                              setRecapRowsShown(1);
-                            }
-                          }}
+                          onClick={() => setShowMoreRecaps(!showMoreRecaps)}
                         >
-                          {!showMoreRecaps ? "Show more recaps" : recapResults.length - 1 > recapRowsShown * recapColumns ? "Show more" : "Show less"}
+                          {showMoreRecaps ? "Show less" : "Show more recaps"}
                           <span className={`recaps-chevron${showMoreRecaps ? " open" : ""}`}>
                             <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6 6-6" /></svg>
                           </span>
                         </button>
                         {showMoreRecaps && (
-                          <div className="recaps-grid" ref={recapsGridRef}>
-                            {recapResults.slice(1, 1 + recapRowsShown * recapColumns).map((r: any) => (
+                          <div className="recaps-grid">
+                            {recapResults.slice(1).map((r: any) => (
                               <button
                                 key={r.videoId}
                                 className={`recap-card${selectedRecap?.videoId === r.videoId ? " active" : ""}`}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { fetchMovie, fetchTV, fetchSeason, fetchEpisodeGroups, fetchReviews, searchStreams, playTorrent, backdrop, poster, still, fetchResumePoint, fetchSeriesProgress, checkSaved, toggleSaved, reportWatchProgress, castProfile, getPluginStatus, checkAvailability, fetchYoutubeSearch } from "../lib/api";
 import { ratingColor, formatBytes } from "../lib/utils";
@@ -107,9 +107,15 @@ export default function Detail() {
   const [recapLoading, setRecapLoading] = useState(false);
   const [selectedRecap, setSelectedRecap] = useState<any>(null);
   const [recapExpanded, setRecapExpanded] = useState(false);
+  const [recapStickyActive, setRecapStickyActive] = useState(false);
+  const [recapStickyTop, setRecapStickyTop] = useState(56);
   const [recapMinimized, setRecapMinimized] = useState(false);
   const [showMoreRecaps, setShowMoreRecaps] = useState(false);
+  const [visibleRecapCount, setVisibleRecapCount] = useState<number | null>(null);
   const [recapSeason, setRecapSeason] = useState(selectedSeason);
+  const recapsSectionRef = useRef<HTMLDivElement>(null);
+  const recapsToggleRef = useRef<HTMLButtonElement>(null);
+  const recapsGridRef = useRef<HTMLDivElement>(null);
   const [recoveryKey, setRecoveryKey] = useState(0);
   useRefetchOnRecovery(useCallback(() => setRecoveryKey((k) => k + 1), []));
   const [showPluginPrompt, setShowPluginPrompt] = useState(false);
@@ -503,6 +509,61 @@ export default function Detail() {
     setRecapSeason(selectedSeason);
   }, [selectedSeason]);
 
+  function getRecapStickyTop(): number {
+    const navbar = document.querySelector(".navbar") as HTMLElement | null;
+    return navbar?.getBoundingClientRect().bottom || 56;
+  }
+
+  useEffect(() => {
+    if (!recapExpanded) {
+      setRecapStickyActive(false);
+      return;
+    }
+    const media = window.matchMedia("(max-width: 768px)");
+    const updateSticky = () => {
+      const topOffset = getRecapStickyTop();
+      setRecapStickyTop(topOffset);
+      if (!media.matches) {
+        setRecapStickyActive(false);
+        return;
+      }
+      const section = recapsSectionRef.current;
+      const toggle = recapsToggleRef.current;
+      if (!section || !toggle) return;
+      const sectionRect = section.getBoundingClientRect();
+      const toggleRect = toggle.getBoundingClientRect();
+      const shouldStick = sectionRect.top <= topOffset && sectionRect.bottom > topOffset + toggleRect.height + 12;
+      setRecapStickyActive(shouldStick);
+    };
+    updateSticky();
+    window.addEventListener("scroll", updateSticky, { passive: true });
+    window.addEventListener("resize", updateSticky);
+    return () => {
+      window.removeEventListener("scroll", updateSticky);
+      window.removeEventListener("resize", updateSticky);
+    };
+  }, [recapExpanded]);
+
+  useLayoutEffect(() => {
+    if (!showMoreRecaps) {
+      setVisibleRecapCount(null);
+      return;
+    }
+    const measure = () => {
+      const grid = recapsGridRef.current;
+      if (!grid) return;
+      const cols = window.getComputedStyle(grid)
+        .gridTemplateColumns
+        .split(" ")
+        .filter(Boolean)
+        .length;
+      setVisibleRecapCount(Math.max(1, cols));
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [showMoreRecaps, recapResults.length]);
+
   // Refresh recaps when the recap season changes
   useEffect(() => {
     setRecapResults([]);
@@ -516,6 +577,30 @@ export default function Detail() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recapSeason]);
+
+  function handleRecapsToggle() {
+    if (!recapExpanded) {
+      setRecapExpanded(true);
+      if (recapResults.length === 0 && data) {
+        const q = `${data.name || data.title} season ${recapSeason} recap`;
+        setRecapQuery(q);
+        doRecapSearch(q);
+      }
+      return;
+    }
+
+    setRecapExpanded(false);
+    setRecapStickyActive(false);
+    setShowMoreRecaps(false);
+    setVisibleRecapCount(null);
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      const toggle = recapsToggleRef.current;
+      if (!toggle) return;
+      const topOffset = getRecapStickyTop();
+      const top = toggle.getBoundingClientRect().top + window.scrollY - topOffset;
+      window.scrollTo({ top: Math.max(0, top), behavior: "auto" });
+    }));
+  }
 
   if (!data) {
     return (
@@ -688,17 +773,12 @@ export default function Detail() {
 
         {/* ── Recaps (YouTube, for TV shows) ── */}
         {type === "tv" && data && (
-          <div className="recaps-section">
+          <div className="recaps-section" ref={recapsSectionRef}>
             <button
-              className={`recaps-toggle${recapExpanded ? " expanded" : ""}`}
-              onClick={() => {
-                setRecapExpanded(!recapExpanded);
-                if (!recapExpanded && recapResults.length === 0) {
-                  const q = `${data.name || data.title} season ${recapSeason} recap`;
-                  setRecapQuery(q);
-                  doRecapSearch(q);
-                }
-              }}
+              ref={recapsToggleRef}
+              className={`recaps-toggle${recapExpanded ? " expanded" : ""}${recapStickyActive ? " is-stuck" : ""}`}
+              style={{ ["--recaps-sticky-top" as string]: `${recapStickyTop}px` }}
+              onClick={handleRecapsToggle}
             >
               <div className="recaps-toggle-left">
                 <svg className="recaps-toggle-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -868,8 +948,8 @@ export default function Detail() {
                           </span>
                         </button>
                         {showMoreRecaps && (
-                          <div className="recaps-grid">
-                            {recapResults.slice(1).map((r: any) => (
+                          <div className="recaps-grid" ref={recapsGridRef}>
+                            {recapResults.slice(1, 1 + (visibleRecapCount ?? (recapResults.length - 1))).map((r: any) => (
                               <button
                                 key={r.videoId}
                                 className={`recap-card${selectedRecap?.videoId === r.videoId ? " active" : ""}`}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { fetchMovie, fetchTV, fetchSeason, fetchEpisodeGroups, fetchReviews, searchStreams, playTorrent, backdrop, poster, still, fetchResumePoint, fetchSeriesProgress, checkSaved, toggleSaved, reportWatchProgress, castProfile, getPluginStatus, checkAvailability, fetchYoutubeSearch } from "../lib/api";
 import { ratingColor, formatBytes } from "../lib/utils";
@@ -109,7 +109,10 @@ export default function Detail() {
   const [recapExpanded, setRecapExpanded] = useState(false);
   const [recapMinimized, setRecapMinimized] = useState(false);
   const [showMoreRecaps, setShowMoreRecaps] = useState(false);
+  const [recapRowsShown, setRecapRowsShown] = useState(1);
+  const [recapColumns, setRecapColumns] = useState(3);
   const [recapSeason, setRecapSeason] = useState(selectedSeason);
+  const recapsGridRef = useRef<HTMLDivElement>(null);
   const [recoveryKey, setRecoveryKey] = useState(0);
   useRefetchOnRecovery(useCallback(() => setRecoveryKey((k) => k + 1), []));
   const [showPluginPrompt, setShowPluginPrompt] = useState(false);
@@ -127,6 +130,7 @@ export default function Detail() {
     setRecapExpanded(false);
     setRecapMinimized(false);
     setShowMoreRecaps(false);
+    setRecapRowsShown(1);
     setShowAllReddit(false);
     setShowAllReviews(false);
     setResumePoint(null);
@@ -509,6 +513,7 @@ export default function Detail() {
     setSelectedRecap(null);
     setRecapMinimized(false);
     setShowMoreRecaps(false);
+    setRecapRowsShown(1);
     if (recapExpanded && data) {
       const q = `${data.name || data.title} season ${recapSeason} recap`;
       setRecapQuery(q);
@@ -516,6 +521,24 @@ export default function Detail() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recapSeason]);
+
+  // Measure grid columns from actual DOM (before paint, no flash).
+  // Uses window resize — NOT ResizeObserver on the grid, to avoid the
+  // feedback loop where adding items changes grid size → observer fires
+  // → column count changes → item count changes → repeat.
+  useLayoutEffect(() => {
+    if (!showMoreRecaps) return;
+    const grid = recapsGridRef.current;
+    if (!grid) return;
+    const measure = () => {
+      const cols = window.getComputedStyle(grid)
+        .gridTemplateColumns.split(" ").filter(Boolean).length;
+      if (cols > 0) setRecapColumns(cols);
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [showMoreRecaps]);
 
   if (!data) {
     return (
@@ -860,16 +883,33 @@ export default function Detail() {
                       <>
                         <button
                           className="recaps-more-toggle"
-                          onClick={() => setShowMoreRecaps(!showMoreRecaps)}
+                          onClick={() => {
+                            if (!showMoreRecaps) {
+                              setShowMoreRecaps(true);
+                            } else {
+                              const visible = recapRowsShown * recapColumns;
+                              const remaining = recapResults.length - 1 - visible;
+                              if (remaining > 0) {
+                                setRecapRowsShown((r) => r + 1);
+                              } else {
+                                setShowMoreRecaps(false);
+                                setRecapRowsShown(1);
+                              }
+                            }
+                          }}
                         >
-                          {showMoreRecaps ? "Show less" : "Show more recaps"}
+                          {(() => {
+                            if (!showMoreRecaps) return "Show more recaps";
+                            const remaining = recapResults.length - 1 - recapRowsShown * recapColumns;
+                            return remaining > 0 ? "Show more" : "Show less";
+                          })()}
                           <span className={`recaps-chevron${showMoreRecaps ? " open" : ""}`}>
                             <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6 6-6" /></svg>
                           </span>
                         </button>
                         {showMoreRecaps && (
-                          <div className="recaps-grid">
-                            {recapResults.slice(1).map((r: any) => (
+                          <div className="recaps-grid" ref={recapsGridRef}>
+                            {recapResults.slice(1, 1 + recapRowsShown * recapColumns).map((r: any) => (
                               <button
                                 key={r.videoId}
                                 className={`recap-card${selectedRecap?.videoId === r.videoId ? " active" : ""}`}

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { fetchMovie, fetchTV, fetchSeason, fetchEpisodeGroups, fetchReviews, searchStreams, playTorrent, backdrop, poster, still, fetchResumePoint, fetchSeriesProgress, checkSaved, toggleSaved, reportWatchProgress, castProfile, getPluginStatus, checkAvailability, fetchYoutubeSearch } from "../lib/api";
 import { ratingColor, formatBytes } from "../lib/utils";
@@ -109,10 +109,7 @@ export default function Detail() {
   const [recapExpanded, setRecapExpanded] = useState(false);
   const [recapMinimized, setRecapMinimized] = useState(false);
   const [showMoreRecaps, setShowMoreRecaps] = useState(false);
-  const [recapRowsShown, setRecapRowsShown] = useState(1);
-  const [recapColumns, setRecapColumns] = useState(3);
   const [recapSeason, setRecapSeason] = useState(selectedSeason);
-  const recapsGridRef = useRef<HTMLDivElement>(null);
   const [recoveryKey, setRecoveryKey] = useState(0);
   useRefetchOnRecovery(useCallback(() => setRecoveryKey((k) => k + 1), []));
   const [showPluginPrompt, setShowPluginPrompt] = useState(false);
@@ -130,7 +127,6 @@ export default function Detail() {
     setRecapExpanded(false);
     setRecapMinimized(false);
     setShowMoreRecaps(false);
-    setRecapRowsShown(1);
     setShowAllReddit(false);
     setShowAllReviews(false);
     setResumePoint(null);
@@ -513,7 +509,6 @@ export default function Detail() {
     setSelectedRecap(null);
     setRecapMinimized(false);
     setShowMoreRecaps(false);
-    setRecapRowsShown(1);
     if (recapExpanded && data) {
       const q = `${data.name || data.title} season ${recapSeason} recap`;
       setRecapQuery(q);
@@ -521,24 +516,6 @@ export default function Detail() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recapSeason]);
-
-  // Measure grid columns from actual DOM (before paint, no flash).
-  // Uses window resize — NOT ResizeObserver on the grid, to avoid the
-  // feedback loop where adding items changes grid size → observer fires
-  // → column count changes → item count changes → repeat.
-  useLayoutEffect(() => {
-    if (!showMoreRecaps) return;
-    const grid = recapsGridRef.current;
-    if (!grid) return;
-    const measure = () => {
-      const cols = window.getComputedStyle(grid)
-        .gridTemplateColumns.split(" ").filter(Boolean).length;
-      if (cols > 0) setRecapColumns(cols);
-    };
-    measure();
-    window.addEventListener("resize", measure);
-    return () => window.removeEventListener("resize", measure);
-  }, [showMoreRecaps]);
 
   if (!data) {
     return (
@@ -883,33 +860,16 @@ export default function Detail() {
                       <>
                         <button
                           className="recaps-more-toggle"
-                          onClick={() => {
-                            if (!showMoreRecaps) {
-                              setShowMoreRecaps(true);
-                            } else {
-                              const visible = recapRowsShown * recapColumns;
-                              const remaining = recapResults.length - 1 - visible;
-                              if (remaining > 0) {
-                                setRecapRowsShown((r) => r + 1);
-                              } else {
-                                setShowMoreRecaps(false);
-                                setRecapRowsShown(1);
-                              }
-                            }
-                          }}
+                          onClick={() => setShowMoreRecaps(!showMoreRecaps)}
                         >
-                          {(() => {
-                            if (!showMoreRecaps) return "Show more recaps";
-                            const remaining = recapResults.length - 1 - recapRowsShown * recapColumns;
-                            return remaining > 0 ? "Show more" : "Show less";
-                          })()}
+                          {showMoreRecaps ? "Show less" : "Show more recaps"}
                           <span className={`recaps-chevron${showMoreRecaps ? " open" : ""}`}>
                             <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6 6-6" /></svg>
                           </span>
                         </button>
                         {showMoreRecaps && (
-                          <div className="recaps-grid" ref={recapsGridRef}>
-                            {recapResults.slice(1, 1 + recapRowsShown * recapColumns).map((r: any) => (
+                          <div className="recaps-grid">
+                            {recapResults.slice(1).map((r: any) => (
                               <button
                                 key={r.videoId}
                                 className={`recap-card${selectedRecap?.videoId === r.videoId ? " active" : ""}`}


### PR DESCRIPTION
## Summary
This PR is the full review surface for the **3.0.3** candidate. `main` was reset back to the `v3.0.2` release commit; this branch carries the recap/mobile work that should land next.

## Scope
Files changed:
- `package.json`
- `package-lock.json`
- `src/pages/Detail.tsx`
- `src/pages/Detail.css`

## What changed
### Versioning
- bump app version to **3.0.3** in `package.json`
- align the root package metadata in `package-lock.json` to **3.0.3**

### Recaps UX
- add the YouTube recaps section for TV detail pages
- keep one suggested recap visible by default
- show one exact row of extra recap options behind **Show more recaps**
- remove the old clipping approach and render exactly one row worth of cards based on actual grid columns

### Mobile polish
- sticky recap toggle on mobile only, and only while actually stuck
- sticky offset derived from the real navbar bottom at runtime
- collapsing the recaps section restores scroll to the recap toggle
- sticky state animates to full-width while stuck

### CSS / behavior fixes
- fix the `fadeUp` animation so it no longer leaves a persistent transform that breaks `position: sticky`
- no new dependencies
- no extracted helpers/shared abstractions beyond what stays inside the existing detail page implementation

## Provenance
This PR contains the post-`v3.0.2` recap/mobile work plus the `3.0.3` version bump.

Commit authors on this branch are all:
- `narzaut <narzaut@users.noreply.github.com>`

I do **not** see any non-self-authored commits in this PR.

## Verification
### Passes
- `tsc --noEmit`
- `npm run build`

### Existing unrelated red test on base `main` and this branch
Full `npm test` is already red outside this PR, in `test/routes/search.test.ts`:
- `returns 503 when no plugin is installed`
- actual behavior: `200 !== 503`

That failure reproduces on both:
- `main` at `v3.0.2`
- this PR branch

So it is **not introduced by this PR**.

## CI/CD note
The release workflow is **tag-driven**:
- `.github/workflows/release.yml`
- trigger: `push.tags: v*`

So merging this PR will **not** publish a release by itself. The next release pipeline for `3.0.3` is kicked off by pushing tag `v3.0.3`.