### PR TITLE
fix: use bundled runtime for Windows plugin installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rattin",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rattin",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "GPL-3.0-only",
       "dependencies": {
         "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rattin",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "",
   "type": "module",
   "main": "server.ts",

--- a/shell/main.cpp
+++ b/shell/main.cpp
@@ -171,6 +171,7 @@ int main(int argc, char *argv[])
 #ifdef Q_OS_WIN
     // Pass config dir to Node.js so lib/paths.ts uses the same location
     env.insert("MAGNET_CONFIG_DIR", configDir);
+    env.insert("MAGNET_NODE_PATH", QDir(binDir).filePath("rattin-runtime.exe"));
     // Add the directory containing rattin-runtime.exe to PATH
     QString nodePath = QDir(binDir).canonicalPath();
     env.insert("PATH", nodePath + ";" + env.value("PATH"));


### PR DESCRIPTION
## Summary
- set `MAGNET_NODE_PATH` in the Windows shell environment to the bundled `rattin-runtime.exe`
- keep plugin child-process spawns off global Node installs
- fix packaged Windows installs that fail with `spawn node ENOENT` during plugin install

## Test Plan
- reproduced the failure locally by removing global Node and leaving only a bundled-runtime-style executable name available
- verified plugin spawn fails with `spawn node ENOENT` when no `MAGNET_NODE_PATH` is provided
- verified plugin install works when `MAGNET_NODE_PATH` points at the bundled runtime path
